### PR TITLE
Adjust node versions under test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@
 language: cpp
 sudo: false
 env:
-  - export NODE_VERSION="0.10"
-  - export NODE_VERSION="0.12"
   - export NODE_VERSION="4"
-  - export NODE_VERSION="5"
+  - export NODE_VERSION="6"
+  - export NODE_VERSION="8"
 os:
   - linux
   - osx

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,11 +242,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
-    "axios": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
-      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0="
-    },
     "axobject-query": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
@@ -1695,11 +1690,6 @@
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw="
     },
-    "dotenv": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
-      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0="
-    },
     "download": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/download/-/download-4.4.3.tgz",
@@ -2323,11 +2313,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I="
-    },
-    "follow-redirects": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.3.tgz",
-      "integrity": "sha1-AauuyoXjYJg32fzaMWen5C/ayiE="
     },
     "for-in": {
       "version": "1.0.2",


### PR DESCRIPTION
The current Travis-CI checks take ~40 minutes to complete. We are testing depreciated versions of node. This PR instructs Travis only to test LTS and current versions of node.