### PR TITLE
Added .DS_Store files to Git Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
+# Custom Ignores
 package-lock.json
-
 navData.json
 .svn
+*.DS_Store
 
 # Logs
 logs


### PR DESCRIPTION
This pull request adds .DS_Store files to Git Ignore, developers on macOS may accidentally commit these local files to the Git repo - it would make sense to add it to Git Ignore to accommodate for those developers. If the maintainers agree with this change, it should be merged.