### PR TITLE
Fixed link to guides website

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # freeCodeCamp Guides
 The freeCodeCamp community is building a massive, searchable "Guide." This reference tool will eventually include thousands of articles that cover all areas of development, design, and data science - all written to be easily understood by people new to coding.
 
-This repo is where we plan and maintain these guide articles, which we then host on our community's wiki-like [guides website](guide.netlify.com).
+This repo is where we plan and maintain these guide articles, which we then host on our community's wiki-like [guides website](http://guide.netlify.com).
 
 **Table of Contents**
 


### PR DESCRIPTION
The link to the guides website in the introduction was broken, this change fixes it.