### PR TITLE
Updated .eslintrc 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "parserOption": {
+  "parserOptions": {
     "ecmaVersion": 6,
     "ecmaFeatures": {
       "jsx": true

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babel-eslint": "^7.2.3",
     "caniuse-db": "^1.0.30000700",
-    "eslint": "^3.19.0",
+    "eslint": "^4.3.0",
     "eslint-config-google": "^0.7.1",
     "eslint-plugin-flowtype": "^2.34.1",
     "eslint-plugin-import": "^2.3.0",


### PR DESCRIPTION
Was `parserOption` in line 2 before which was not compatible with ESlint version 4.3.0.