### PR TITLE
Add pre-commit hook to run lint and normaliseArticles

### DIFF
--- a/_normaliseArticles.js
+++ b/_normaliseArticles.js
@@ -1,15 +1,20 @@
 const Rx = require('rx');
 const fse = require('fs-extra');
+const chalk = require('chalk');
 
 const { titleify } = require('./seed/utils');
 
 const { Observable } = Rx;
 
+function info(str, colour = 'red') {
+  console.log(chalk[colour](str));
+}
+
 const metaRE = /---[\W\w]*?---\n*?/;
 const isAFileRE = /(\.md|\.jsx?|\.html?)$/;
 const shouldBeIgnoredRE = /^(\_|\.)/;
 const isAStubRE = /This\sis\sa\sstub\.\s\[Help\sour\scommunity\sexpand\sit\]/;
-const markdownLinkRE = /\!?\[[\w\W]*?\]\([\w\W]+?\)/g;
+const markdownLinkRE = /\!?\[.*?\]\(.+?\)/g;
 const httpsRE = /https?\:\/\//;
 
 const articlesDir = `${process.cwd()}/src/pages/articles`;
@@ -142,5 +147,6 @@ applyNormaliser(articlesDir)
     },
     () => {
       normaliseMeta(articlesDir);
-      console.info('\n\nNormalisation Completed\n\n');
+      info('\n\nNormalisation Completed\n\n', 'greenBright');
+      info('Please check for uncommited changes before pushing\n', 'yellow');
     });

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "typography-plugin-code": "^0.15.9"
   },
   "devDependencies": {
-    "gh-pages": "^0.12.0"
+    "chalk": "^2.0.1",
+    "gh-pages": "^0.12.0",
+    "pre-commit": "^1.2.2"
   },
   "keywords": [
     "freeCodeCamp",
@@ -51,6 +53,11 @@
     "dev": "node seed && gatsby develop",
     "format": "prettier --trailing-comma es5 --no-semi --single-quote --write \"pages/*.js\" \"utils/*.js\" \"wrappers/*.js\" \"html.js\"",
     "lint": "eslint --ext .js,.jsx --ignore-path .gitignore .",
+    "normalise": "node _normaliseArticles.js",
     "test": "echo \"Error: no test specified\" && exit 1"
-  }
+  },
+  "pre-commit": [
+    "lint",
+    "normalise"
+  ]
 }

--- a/src/pages/articles/git/index.md
+++ b/src/pages/articles/git/index.md
@@ -36,7 +36,7 @@ The **staging area** is a file (also called the "index", "stage", or "cache") th
 With three sections, there are three main states that a file can be in at any given time: committed, modified, or staged. You *modify* a file any time you make changes to it in your working directory. Next, it's *staged* when you move it to the staging area. Finally, it's *committed* after a commit.
 
 ### Install Git
-You can install Git by visiting the [Git Downloads page](https://git-scm.com/downloads) and finding the right version for your operating system.
+You can install Git by visiting the <a href='https://git-scm.com/downloads' target='_blank' rel='nofollow'>Git Downloads page</a> and finding the right version for your operating system.
 
 ### Configure the Git Environment
 Git has a `git config` tool that allows you to customize your Git environment. You can change the way Git looks and functions by setting certain configuration variables. Run these commands from a command line interface on your machine (Terminal in Mac, Command Prompt or Powershell in Windows).
@@ -89,7 +89,7 @@ This displays the manual page for the command in your shell window. To navigate,
 - `q` to quit
 
 ### Sources
-This article uses information from the [Pro Git](https://github.com/progit/progit2) book, written by Scott Chacon and Ben Straub and published by Apress. The book is displayed in full in the [Git documentation](https://git-scm.com/book/en/v2).
+This article uses information from the <a href='https://github.com/progit/progit2' target='_blank' rel='nofollow'>Pro Git</a> book, written by Scott Chacon and Ben Straub and published by Apress. The book is displayed in full in the <a href='https://git-scm.com/book/en/v2' target='_blank' rel='nofollow'>Git documentation</a>.
 
 ### Other Resources
-Visit the [Git official website](https://git-scm.com/) to find downloads, documentation, and a browser-based tutorial.
+Visit the <a href='https://git-scm.com/' target='_blank' rel='nofollow'>Git official website</a> to find downloads, documentation, and a browser-based tutorial.

--- a/src/pages/articles/sql/sql-create-table/index.md
+++ b/src/pages/articles/sql/sql-create-table/index.md
@@ -120,5 +120,5 @@ Try [this download for Windows users[(https://dev.mysql.com/downloads/windows/)
 
 
 ### MySQL documentation
-* [manual page](https://dev.mysql.com/doc/refman/5.7/en/alter-table.html)
-* [examples from manual](https://dev.mysql.com/doc/refman/5.7/en/alter-table-examples.html)
+* <a href='https://dev.mysql.com/doc/refman/5.7/en/alter-table.html' target='_blank' rel='nofollow'>manual page</a>
+* <a href='https://dev.mysql.com/doc/refman/5.7/en/alter-table-examples.html' target='_blank' rel='nofollow'>examples from manual</a>


### PR DESCRIPTION
This PR runs lint and normaliseArticles before any changes are committed.

If either script fails, the changes are not committed. Allowing contributors the chance to fix linting errors before pushing a PR.

closes #101 