### PR TITLE
Added freeCodeCamp's favicon

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -5,6 +5,10 @@ import Helmet from 'react-helmet';
 import { TypographyStyle } from 'react-typography';
 import typography from './utils/typography';
 
+import fccMetaTags from './meta.js';
+
+const meta = fccMetaTags();
+
 export default class HTML extends React.Component {
   static propTypes = {
     body: PropTypes.string,
@@ -51,6 +55,7 @@ export default class HTML extends React.Component {
             }
             rel='stylesheet'
           />
+          {meta}
           <title>freeCodeCamp Guide</title>
           <TypographyStyle typography={typography} />
           {css}

--- a/src/meta.js
+++ b/src/meta.js
@@ -1,0 +1,233 @@
+import React from 'react';
+
+function fccMetaTags() {
+  return [
+    <link
+      href='https://s3.amazonaws.com/freecodecamp/favicons/favicon.ico'
+      rel='icon'
+      type='image/x-icon'
+    />,
+    <link
+      href='https://s3.amazonaws.com/freecodecamp/favicons/favicon.ico'
+      rel='favicon'
+    />,
+    <link
+      href='https://s3.amazonaws.com/freecodecamp/favicons/favicon.ico'
+      rel='shortcut icon'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'favicon-16x16.png'
+      }
+      rel='favion'
+      sizes='16x16'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'favicon-32x32.png'
+      }
+      rel='favicon'
+      sizes='32x32'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'favicon-96x96.png'
+      }
+      rel='favicon'
+      sizes='96x96'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'android-chrome-36x36.png'
+      }
+      rel='android-chrome'
+      sizes='36x36'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'android-chrome-48x48.png'
+      }
+      rel='android-chrome'
+      sizes='48x48'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'android-chrome-72x72.png'
+      }
+      rel='android-chrome'
+      sizes='72x72'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'android-chrome-96x96.png'
+      }
+      rel='android-chrome'
+      sizes='96x96'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'android-chrome-144x144.png'
+      }
+      rel='android-chrome'
+      sizes='144x144'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'android-chrome-192x192.png'
+      }
+      rel='android-chrome'
+      sizes='192x192'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'android-chrome-manifest.json'
+      }
+      rel='android-chrome-manifest'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-precomposed.png'
+      }
+      rel='apple-touch-icon-precomposed'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon.png'
+      }
+      rel='apple-touch-icon'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-57x57.png'
+      }
+      rel='apple-touch-icon'
+      sizes='57x57'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-60x60.png'
+      }
+      rel='apple-touch-icon'
+      sizes='60x60'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-72x72.png'
+      }
+      rel='apple-touch-icon'
+      sizes='72x72'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-76x76.png'
+      }
+      rel='apple-touch-icon'
+      sizes='76x76'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-114x114.png'
+      }
+      rel='apple-touch-icon'
+      sizes='114x114'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-120x120.png'
+      }
+      rel='apple-touch-icon'
+      sizes='120x120'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-144x144.png'
+      }
+      rel='apple-touch-icon'
+      sizes='144x144'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-152x152.png'
+      }
+      rel='apple-touch-icon'
+      sizes='152x152'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'apple-touch-icon-180x180.png'
+      }
+      rel='apple-touch-icon'
+      sizes='180x180'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'mstile-70x70.png'
+      }
+      rel='mstile'
+      sizes='70x70'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'mstile-144x144.png'
+      }
+      rel='mstile'
+      sizes='144x144'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'mstile-150x150.png'
+      }
+      rel='mstile'
+      sizes='150x150'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'mstile-310x150.png'
+      }
+      rel='mstile'
+      sizes='310x150'
+    />,
+    <link
+      href={
+        'https://s3.amazonaws.com/freecodecamp/favicons/' +
+        'mstile-310x310.png'
+      }
+      rel='mstile'
+      sizes='310x310'
+    />,
+    <meta
+      content='#FFFFFF'
+      name='msapplication-TileColor'
+    />,
+    <meta
+      content='/'
+      name='msapplication-TileImage'
+    />
+  ].map((Component, i) => ({ ...Component, key: i }));
+}
+export default fccMetaTags;


### PR DESCRIPTION
Just like the freeCodeCamp curriculum and forums - the guides website should have freeCodeCamp's favicon. This PR adds the favicon to provide a consistent user experience.