### PR TITLE
Change dev npm script to run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "_comment": "ONLY RUN BUILD IF YOUR SYSTEM HAS 8GB OR MORE OF RAM",
     "build": "node seed && node --max_old_space_size=7168 ./node_modules/.bin/gatsby build",
-    "dev": "node seed && node --max_old_space_size=7168 ./node_modules/.bin/gatsby develop",
+    "dev": "node seed && gatsby develop",
     "lint": "eslint --ext .js,.jsx --ignore-path .gitignore .",
     "normalise": "node _normaliseArticles.js",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Addresses #169

In a DM on Gitter, @Bouncey mentioned the extra memory was not required for the dev script. I have removed it so that the dev script now also works on Windows.

I think this closes #169 