### PR TITLE
Add gitattributes to resolve normalise line-ending issue on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ignore differences in line endings
+# The _normaliseArticles.js script causes the line endings for all articles to change when it is run on Windows
+*.md      -text


### PR DESCRIPTION
Yet another Windows issue!

Any time I created a commit, the `_normaliseArticles.js` script was run. On Windows, it would change the line endings from LF to CRLF. After every commit, I would end up with 2000+ changed files 😥 

The solution I used was taken from [this blog article](http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/). As far as I can tell, it works the way it's supposed to. The normalise script still runs, but the changed line endings are ignored.
