### PR TITLE
Add pre-commit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,10 +62,12 @@
     "build": "node seed && node --max_old_space_size=7168 ./node_modules/.bin/gatsby build",
     "dev": "node seed && gatsby develop",
     "lint": "eslint --ext .js,.jsx --ignore-path .gitignore .",
+    "pre-commit-message": "echo \"Running pre-commit script. This can take a while.\"",
     "normalise": "node _normaliseArticles.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "pre-commit": [
+    "pre-commit-message",
     "lint",
     "normalise"
   ]


### PR DESCRIPTION
The first time I created a commit I though it wasn't working. I didn't know that there was a pre-commit script, and nothing was happening, so I assumed something was wrong. This PR adds a message warning of the pre-commit script and that it can take a while to complete.

I tested this in Git Bash and the default command prompt on Windows 10.