### PR TITLE
Add syntax highlighting

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,6 @@ module.exports = {
   },
   plugins: [
     'gatsby-plugin-react-helmet',
-    'gatsby-transformer-remark',
     {
       resolve: 'gatsby-source-filesystem',
       options: {
@@ -14,8 +13,12 @@ module.exports = {
       }
     },
     {
-      resolve: 'gatsby-plugin-sitemap'
+      resolve: 'gatsby-transformer-remark',
+      options: {
+        plugins: ['gatsby-remark-smartypants', 'gatsby-remark-prismjs']
+      }
     },
+    'gatsby-plugin-sitemap',
     'gatsby-plugin-sharp'
   ]
 };

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
     "babel-eslint": "^7.2.3",
     "caniuse-db": "^1.0.30000700",
     "eslint": "^4.3.0",
-    "eslint-config-google": "^0.7.1",
-    "eslint-plugin-flowtype": "^2.34.1",
     "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-react": "^7.0.0",
     "fs-extra": "^3.0.1",
     "gatsby": "bouncey/gatsby#master",
@@ -19,10 +16,7 @@
     "gatsby-plugin-react-helmet": "1.0.1",
     "gatsby-plugin-sharp": "1.6.0",
     "gatsby-plugin-sitemap": "1.2.0",
-    "gatsby-remark-copy-linked-files": "1.5.0",
-    "gatsby-remark-images": "1.5.0",
     "gatsby-remark-prismjs": "1.2.0",
-    "gatsby-remark-responsive-iframe": "1.4.1",
     "gatsby-remark-smartypants": "1.4.1",
     "gatsby-source-filesystem": "1.4.1",
     "gatsby-transformer-remark": "1.6.3",
@@ -42,9 +36,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "chalk": "^2.0.1",
-    "pre-commit": "^1.2.2",
-    "redux-devtools-extension": "^2.13.2",
-    "warning": "^3.0.0"
+    "pre-commit": "^1.2.2"
   },
   "keywords": [
     "freeCodeCamp",

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -12,6 +12,8 @@ import {
   link
 } from './Layout.module.css';
 
+require('prismjs/themes/prism.css');
+
 const propTypes = {
       'location.pathname': PropTypes.string,
       children: PropTypes.func,


### PR DESCRIPTION
The `gatsby-remark-prismjs` package was already in the `package.json`, but it wasn't configured. I think syntax highlighting is nice to have for a site like this, so I decided to set it up. 

I also went through some of the packages to see if they were being used and removed the ones that weren't.

I tested this with the SQL Average Function article, and it worked great.

PrismJS does require you to specify the language. A JS code block would be written like the following

```markdown
```javascript
const prism = 'a popular syntax highlighting library';
```(placeholder)
```
without the `(placeholder)`, that's there because it's the only way GitHub will let me escape the backticks.