### PR TITLE
Move babel presets to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "freeCodeCamp",
   "dependencies": {
     "axios": "^0.16.2",
-    "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
@@ -35,6 +34,7 @@
     "rx": "^4.1.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "chalk": "^2.0.1",
     "pre-commit": "^1.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "author": "freeCodeCamp",
   "dependencies": {
     "axios": "^0.16.2",
+    "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
     "caniuse-db": "^1.0.30000700",
     "eslint": "^4.3.0",
     "eslint-plugin-import": "^2.3.0",
@@ -32,9 +35,6 @@
     "rx": "^4.1.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
     "chalk": "^2.0.1",
     "pre-commit": "^1.2.2"
   },


### PR DESCRIPTION
Whilst building in netlify, it looks like dev-dependencies are not installed. This causes an error and the build process exits with a non-zero exit code, due to `es2015` not being found.