### PR TITLE
Replace netlify.com with freecodecamp.org

### DIFF
--- a/_normaliseArticles.js
+++ b/_normaliseArticles.js
@@ -58,7 +58,8 @@ function normaliseLinks(content) {
     .filter(x => !x.startsWith('!'))
     .filter(x => x.match(httpsRE))
     .map(str => {
-      // raw will look like [ '[guides website', 'http://guide.netlify.com)' ]
+      // raw will look like: 
+      // [ '[guides website', 'http://guide.freecodecamp.org)' ]
       const raw = str.slice(0).split('](');
       const formatted = [ raw[0].replace('[', ''), raw[1].replace(')', '') ];
       const [ childText, url ] = formatted;

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteMetadata: {
-    siteUrl: 'http://guide.netlify.com',
+    siteUrl: 'http://guide.freecodecamp.org',
     title: 'freeCodeCamp Guides'
   },
   plugins: [


### PR DESCRIPTION
Closes https://github.com/freeCodeCamp/guides/issues/224
The one in the comment isn't entirely necessary, but hey, consistency! 😄 