### PR TITLE
Removed extra `x` from python folders

### DIFF
--- a/src/pages/python/python-abs-function/index.md
+++ b/src/pages/python/python-abs-function/index.md
@@ -1,5 +1,5 @@
 ---
-title: Python Absx Function
+title: Python Abs Function
 ---
 `abs()` is a built-in function in Python 3, to compute the absolute value of any number. It takes one argument `x`. The argument can even be a <a href='https://docs.python.org/3.0/library/cmath.html' target='_blank' rel='nofollow'>complex number</a>, and in that case its <a href='http://www.mathcentre.ac.uk/resources/sigma%20complex%20number%20leaflets/sigma-complex9-2009-1.pdf' target='_blank' rel='nofollow'>modulus</a> is returned.
 

--- a/src/pages/python/python-bool-function/index.md
+++ b/src/pages/python/python-bool-function/index.md
@@ -1,5 +1,5 @@
 ---
-title: Python Boolx Function
+title: Python Bool Function
 ---
 `bool()` is a built-in function in Python 3\. This function returns a Boolean value, i.e. True or False. It takes one argument, `x`.
 

--- a/src/pages/python/python-len-function/index.md
+++ b/src/pages/python/python-len-function/index.md
@@ -1,5 +1,5 @@
 ---
-title: Python Lenx Function
+title: Python Len Function
 ---
 `len()` is a built-in function in Python 3\. This method returns the length (the number of items) of an object. It takes one argument `x`.
 


### PR DESCRIPTION
Issue: https://github.com/freeCodeCamp/guides/issues/270
Renamed python function directories and titles. 
Kindly let me know, if any corrections are needed.