### PR TITLE
Check for throttle/debouce echos before querying

### DIFF
--- a/src/LayoutComponents/search/redux/searchEpic.js
+++ b/src/LayoutComponents/search/redux/searchEpic.js
@@ -9,11 +9,11 @@ import {
 } from './';
 
 let previousSearchTerm = '';
-let Xms = 500;
 const requestUrl = 'https://freecodecamp.duckdns.org';
 const nullAction = { type: 'null' };
 
 function searchTermEpic(actions$, { getState }) {
+  const Xms = 500;
   const source$ = actions$
     .filter(({ type }) => type === types.updateSearchTerm);
 
@@ -23,13 +23,6 @@ function searchTermEpic(actions$, { getState }) {
     )
     .flatMap(() => {
       const { searchTerm } = getState().search;
-      // if user is pressing backspace
-      // increase debounce/throttle time
-      if (searchTerm.length < previousSearchTerm.length) {
-        Xms = 1000;
-      } else {
-        Xms = 500;
-      }
       // if the search term is over 2 chars and
       // this is not a throttle/debounce echo
       if (

--- a/src/LayoutComponents/search/redux/searchEpic.js
+++ b/src/LayoutComponents/search/redux/searchEpic.js
@@ -9,11 +9,11 @@ import {
 } from './';
 
 let previousSearchTerm = '';
+let Xms = 500;
 const requestUrl = 'https://freecodecamp.duckdns.org';
 const nullAction = { type: 'null' };
 
 function searchTermEpic(actions$, { getState }) {
-  let Xms = 500;
   const source$ = actions$
     .filter(({ type }) => type === types.updateSearchTerm);
 

--- a/src/LayoutComponents/search/redux/searchEpic.js
+++ b/src/LayoutComponents/search/redux/searchEpic.js
@@ -8,11 +8,12 @@ import {
   updateSearchResults
 } from './';
 
+let previousSearchTerm = '';
 const requestUrl = 'https://freecodecamp.duckdns.org';
 const nullAction = { type: 'null' };
 
 function searchTermEpic(actions$, { getState }) {
-  const Xms = 400;
+  let Xms = 500;
   const source$ = actions$
     .filter(({ type }) => type === types.updateSearchTerm);
 
@@ -22,9 +23,23 @@ function searchTermEpic(actions$, { getState }) {
     )
     .flatMap(() => {
       const { searchTerm } = getState().search;
-      if (searchTerm.length > 2) {
+      // if user is pressing backspace
+      // increase debounce/throttle time
+      if (searchTerm.length < previousSearchTerm.length) {
+        Xms = 1000;
+      } else {
+        Xms = 500;
+      }
+      // if the search term is over 2 chars and
+      // this is not a throttle/debounce echo
+      if (
+        searchTerm.length > 2 &&
+        searchTerm.length !== previousSearchTerm.length
+      ) {
+        previousSearchTerm = searchTerm.slice(0);
         return Observable.of(fetchSearchResults());
-    }
+      }
+      previousSearchTerm = searchTerm.slice(0);
       return Observable.of(nullAction);
     });
 }

--- a/src/pages/search/Search.jsx
+++ b/src/pages/search/Search.jsx
@@ -57,7 +57,7 @@ function SearchPage(props) {
       </Helmet>
       <h2 className='colourDarkGrey'>Search Results</h2>
       {
-        isSearching ?
+        (isSearching && !results.length) ?
           <ResultsSkeleton /> :
           shouldShowResults({ results, lastPage, searchTerm })
       }


### PR DESCRIPTION
closes #230 

Check for throttle/debouce echos before querying

Also, if we have results, there is no need to display the skeleton again