### PR TITLE
Fix capitalisation of "JavaScript" in index

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -19,8 +19,8 @@ function Index() {
       <p>There are articles on:</p>
         <ul>
           <li>SQL</li>
-          <li>Math</li>
-          <li>javaScript</li>
+          <li>Mathematics</li>
+          <li>JavaScript</li>
           <li>Bootstrap</li>
           <li>Git</li>
           <li>and a whole lot more</li>

--- a/src/pages/python/how-to-convert-strings-into-integers-in-python/index.md
+++ b/src/pages/python/how-to-convert-strings-into-integers-in-python/index.md
@@ -66,6 +66,6 @@ But you should keep in mind some special cases:
     ```
 
 #### More Information:
-Official documentation for `int()` built-in can be found [here](https://docs.python.org/3.6/library/functions.html#int)
+Official documentation for `int()` built-in can be found <a href='https://docs.python.org/3.6/library/functions.html#int' target='_blank' rel='nofollow'>here</a>
 
 


### PR DESCRIPTION
I noticed the capitalisation of "JavaScript" in the index was off, so I fixed it 😄