### PR TITLE
Add a badge for stubs

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -200,8 +200,19 @@
   overflow-y: scroll;
   max-height: 90vh;
 }
+
 .stubbed {
-  color: #999;
+  color: #777;
+}
+
+.stubbed::after {
+  content: 'stub';
+  background-color: #aaa;
+  color: #fff;
+  border-radius: 3px;
+  padding: 0 4px;
+  margin-left: 5px;
+  line-height: 1;
 }
 
 .title {


### PR DESCRIPTION
From https://github.com/freeCodeCamp/guides/pull/279#issuecomment-330210215:
>I really like this change!
Idea: add a badge to stubbed articles to make it clear what it means when an article is grey.
![Stub badge](https://user-images.githubusercontent.com/7262039/30542508-f26babd2-9c7f-11e7-8b3e-ed56fe95833d.png)

If you don't like this (I could see how it might be too much) or want it to be different, let me know!