### PR TITLE
Change 'guides' to 'guide' in code

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   siteMetadata: {
     siteUrl: 'https://guide.freecodecamp.org',
-    title: 'freeCodeCamp Guides'
+    title: 'freeCodeCamp Guide'
   },
   plugins: [
     'gatsby-plugin-react-helmet',

--- a/src/LayoutComponents/nav/NavPanel.jsx
+++ b/src/LayoutComponents/nav/NavPanel.jsx
@@ -45,7 +45,7 @@ function NoArticles() {
         <a
           href={
             'https://github.com/freeCodeCamp/guides/blob/master/README.md' +
-            '#freecodecamp-guides'
+            '#freecodecamp-guide'
           }
           rel='nofollow'
           target='_blank'

--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -7,7 +7,7 @@ function FourOhFour() {
   return (
     <div className='flexWrapper'>
       <Helmet>
-        <title>404 - Page Not Found | freeCodeCamp Guides</title>
+        <title>404 - Page Not Found | freeCodeCamp Guide</title>
       </Helmet>
       <div className='verticalAlign'>
         <h3>404 - Page not found</h3>

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -5,9 +5,9 @@ function Index() {
   return (
     <div>
       <Helmet>
-        <title>freeCodeCamp Guides</title>
+        <title>freeCodeCamp Guide</title>
       </Helmet>
-      <h2>freeCodeCamp Guides</h2>
+      <h2>freeCodeCamp Guide</h2>
       <p>
         {
           'This website is full of articles about all things related to ' +
@@ -43,7 +43,7 @@ function Index() {
             ' to code.'
           }
         </p>
-        <h3>Contribute to the guides</h3>
+        <h3>Contribute to the Guide</h3>
         <p>
           {
             'This site and the articles on it are '

--- a/src/pages/machine-learning/glossary/index.md
+++ b/src/pages/machine-learning/glossary/index.md
@@ -22,5 +22,5 @@ more details.
 
 ### More Information:
 
-- [Glossary of Terms](http://robotics.stanford.edu/~ronnyk/glossary.html)
-- [Glossary of common Machine Learning, Statistics and Data Science terms](https://www.analyticsvidhya.com/glossary-of-common-statistics-and-machine-learning-terms/)
+- <a href='http://robotics.stanford.edu/~ronnyk/glossary.html' target='_blank' rel='nofollow'>Glossary of Terms</a>
+- <a href='https://www.analyticsvidhya.com/glossary-of-common-statistics-and-machine-learning-terms/' target='_blank' rel='nofollow'>Glossary of common Machine Learning, Statistics and Data Science terms</a>


### PR DESCRIPTION
A follow-up for #287, this time making the naming consistent throughout the codebase.