### PR TITLE
Fix link in JavaScript for-loop article

### DIFF
--- a/src/pages/javascript/for-loop/index.md
+++ b/src/pages/javascript/for-loop/index.md
@@ -3,7 +3,7 @@ title: JavaScript for Loop
 ---
 ### Syntax
 
-> for (<a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for' target='_blank' rel='nofollow'>initialization]; [condition]; [final-expression]) statement
+for ((initialization); (condition); (final-expression)) statement
 
 The javascript `for` statement consists of three expressions and a statement:
 
@@ -55,4 +55,4 @@ There are to ways to fix this code. Set the condition to either `i < arr.length`
     7
     8
 
-links: [MDN</a>
+links: <a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for' target='_blank' rel='nofollow'>MDN</a> 


### PR DESCRIPTION
The for-loop article in the JavaScript section of the guide has a problem with the link where all of the text on the page is a link to the MDN article for for loops:

![image](https://user-images.githubusercontent.com/1348165/30784303-bcc9034c-a14a-11e7-9254-2cc8bfa6b596.png)

This pull request should fix that, adding the link to just the MDN link at the end of the article.