### PR TITLE
Update breadcrumb styling

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -39,16 +39,28 @@
 /* Breadcrumbs */
 
 .breadcrumb {
-  background-color: transparent;
+  display: inline-block;
+  padding: 5px 10px;
+  margin-bottom: 5px;
+  opacity: 0.8;
+  transition: opacity 0.1s ease-out;
+}
+
+.breadcrumb:hover {
+  opacity: 1;
 }
 
 .breadcrumb > li a {
   color: #006400;
-  opacity: 0.6;
 }
 
-.breadcrumb>li+li:before {
-  content: '\f054';
+.breadcrumb > li + li:before {
+  content: '\f105';
+  color: #555;
+}
+
+.breadcrumb > .active {
+  color: #555
 }
 
 /* Layout */

--- a/src/pages/computer-hardware/hard-drives/index.md
+++ b/src/pages/computer-hardware/hard-drives/index.md
@@ -16,6 +16,6 @@ You can think of a hard drive as a pantry: a place to store things that we aren'
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
 
-[Wikipedia](https://en.wikipedia.org/wiki/Hard_disk_drive)
+<a href='https://en.wikipedia.org/wiki/Hard_disk_drive' target='_blank' rel='nofollow'>Wikipedia</a>
 
-[Hard drives vs SSDs](https://www.pcmag.com/article2/0,2817,2404258,00.asp)
+<a href='https://www.pcmag.com/article2/0,2817,2404258,00.asp' target='_blank' rel='nofollow'>Hard drives vs SSDs</a>

--- a/src/pages/css/css-cursors/index.md
+++ b/src/pages/css/css-cursors/index.md
@@ -40,6 +40,6 @@ The cursor property specifies the type of cursor to be displayed when you hover 
 ```
 
 #### More Information:
-Check the above cursor values in action: [codepen](https://codepen.io/chriscoyier/pen/uCwfB)
-Mozilla Developer Network: [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor)
-Browser Support: [caniuse](http://caniuse.com/#search=cursor)
+Check the above cursor values in action: <a href='https://codepen.io/chriscoyier/pen/uCwfB' target='_blank' rel='nofollow'>codepen</a>
+Mozilla Developer Network: <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/cursor' target='_blank' rel='nofollow'>MDN</a>
+Browser Support: <a href='http://caniuse.com/#search=cursor' target='_blank' rel='nofollow'>caniuse</a>

--- a/src/pages/developer-tools/bower/index.md
+++ b/src/pages/developer-tools/bower/index.md
@@ -18,8 +18,8 @@ Install packages with bower install. Bower installs packages to bower_components
     bower install <package>
 ```
 ### More Information:
-The Bower website: [bower.io](https://bower.io)
+The Bower website: <a href='https://bower.io' target='_blank' rel='nofollow'>bower.io</a>
 
-Manage Front End Resources with Bower: [scotch.io](https://scotch.io/tutorials/manage-front-end-resources-with-bower)
+Manage Front End Resources with Bower: <a href='https://scotch.io/tutorials/manage-front-end-resources-with-bower' target='_blank' rel='nofollow'>scotch.io</a>
 
-Streamline Web workflow with Bower: [youtube](https://www.youtube.com/watch?v=Vs2wduoN9Ws)
+Streamline Web workflow with Bower: <a href='https://www.youtube.com/watch?v=Vs2wduoN9Ws' target='_blank' rel='nofollow'>youtube</a>

--- a/src/pages/developer-tools/markdown/index.md
+++ b/src/pages/developer-tools/markdown/index.md
@@ -6,8 +6,8 @@ Markdown is a lightweight markup language with plain text formatting syntax. It 
 
 
 ## More Information:
-A cheatsheet is one of the easiest way to learn Markdown. Check out [this popular cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
+A cheatsheet is one of the easiest way to learn Markdown. Check out <a href='https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet' target='_blank' rel='nofollow'>this popular cheatsheet</a>.
 
-You can also check out this online tutorial: [Markdown Tutorial](https://www.markdowntutorial.com)
+You can also check out this online tutorial: <a href='https://www.markdowntutorial.com' target='_blank' rel='nofollow'>Markdown Tutorial</a>
 
-Love learning by videos? Check out [this Youtube video](https://www.youtube.com/watch?v=HndN6P9ke6U)
+Love learning by videos? Check out <a href='https://www.youtube.com/watch?v=HndN6P9ke6U' target='_blank' rel='nofollow'>this Youtube video</a>

--- a/src/pages/git/git-commit/index.md
+++ b/src/pages/git/git-commit/index.md
@@ -7,7 +7,7 @@ The `git commit` command will save all staged changes, along with a brief descri
 
 Commits are at the heart of Git usage. You can think of a commit as a snapshot of your project, where a new version of that project is created in the current repository. Two important features of commits are:
 
-- you can recall the commited changes at a later date, or revert the project to that version [see Git checkout](https://guide.freecodecamp.org/git/git-checkout) 
+- you can recall the commited changes at a later date, or revert the project to that version <a href='https://guide.freecodecamp.org/git/git-checkout' target='_blank' rel='nofollow'>see Git checkout</a> 
 - if multiple commits edit different parts of the project, they will not overwrite each other even if the authors of the commit were unaware of each other. This is one of the benefits of using Git over a tool like Dropbox or Google Drive.
 
 ### Options

--- a/src/pages/python/list-append-method/index.md
+++ b/src/pages/python/list-append-method/index.md
@@ -21,6 +21,6 @@ print(words)
 
 #### More Information:
 
-The official documentation for `append()` can be found [here](https://docs.python.org/3.6/tutorial/datastructures.html)
+The official documentation for `append()` can be found <a href='https://docs.python.org/3.6/tutorial/datastructures.html' target='_blank' rel='nofollow'>here</a>
 
 

--- a/src/pages/python/list-index-method/index.md
+++ b/src/pages/python/list-index-method/index.md
@@ -51,6 +51,6 @@ Here although the element is searched between the indices 2(inclusive) and 5(not
 
 #### More Information:
 
-The official documentation for `index()` can be found [here](https://docs.python.org/3.6/tutorial/datastructures.html)
+The official documentation for `index()` can be found <a href='https://docs.python.org/3.6/tutorial/datastructures.html' target='_blank' rel='nofollow'>here</a>
 
 

--- a/src/pages/python/list-remove-method/index.md
+++ b/src/pages/python/list-remove-method/index.md
@@ -33,6 +33,6 @@ Traceback (most recent call last):
 ValueError: list.remove(x): x not in list
 ```
 #### More Information:
-More information about `remove()` can be found [here](https://docs.python.org/3.6/tutorial/datastructures.html)
+More information about `remove()` can be found <a href='https://docs.python.org/3.6/tutorial/datastructures.html' target='_blank' rel='nofollow'>here</a>
 
 

--- a/src/pages/svg/index.md
+++ b/src/pages/svg/index.md
@@ -35,7 +35,7 @@ With a viewport in place you can add basic graphics, text, and path elements.
 </svg>  
 ```
 
-You can see the output and play with the code in [this codepen](https://codepen.io/SgiobairOg/pen/OxbNpW). 
+You can see the output and play with the code in <a href='https://codepen.io/SgiobairOg/pen/OxbNpW' target='_blank' rel='nofollow'>this codepen</a>. 
 
 In the opening `svg` tag we add a width attribute to set the width of the viewport to 100% of the container width, you can use percentages or pixel widths. The opening svg tag also has `viewbox` attribute which defines a window through which elements of your svg are visible, in this case, the viewbox spans from (0,0) to (600,300). In SVG space the X-axis starts with zero on the left and increases to the right; the Y-axis starts with zero at the top and increases towards the bottom.
 
@@ -51,9 +51,9 @@ The `<path />` element defines a vector path in the viewport. The path is define
 
 ## Browser Support
 
-[Browser support for SVG](https://caniuse.com/#feat=svg) is available in all modern browsers. There are some issues with scaling in IE 9 through IE 11 however they can be overcome with the use of the `width`, `height`, `viewbox`, and CSS. 
+<a href='https://caniuse.com/#feat=svg' target='_blank' rel='nofollow'>Browser support for SVG</a> is available in all modern browsers. There are some issues with scaling in IE 9 through IE 11 however they can be overcome with the use of the `width`, `height`, `viewbox`, and CSS. 
 
 ## Resources
 
-- [W3C, Scalable Vector Graphics (SVG) 1.1 (Second Edition)](https://www.w3.org/TR/SVG/)
-- [Mozilla Developer Network, SVG](https://developer.mozilla.org/en-US/docs/Web/SVG)
+- <a href='https://www.w3.org/TR/SVG/' target='_blank' rel='nofollow'>W3C, Scalable Vector Graphics (SVG) 1.1 (Second Edition)</a>
+- <a href='https://developer.mozilla.org/en-US/docs/Web/SVG' target='_blank' rel='nofollow'>Mozilla Developer Network, SVG</a>

--- a/src/pages/user-experience-design/hicks-law/index.md
+++ b/src/pages/user-experience-design/hicks-law/index.md
@@ -22,8 +22,8 @@ Reducing the number of perceived options on the screen makes the interface more 
 
 ### More Information:
 
-Hicks' Law - [Wikipedia](https://en.wikipedia.org/wiki/Hick%27s_law)
+Hicks' Law - <a href='https://en.wikipedia.org/wiki/Hick%27s_law' target='_blank' rel='nofollow'>Wikipedia</a>
 
-Design Principles: Hick's Law - [uxplanet](https://uxplanet.org/design-principles-hicks-law-quick-decision-making-3dcc1b1a0632)
+Design Principles: Hick's Law - <a href='https://uxplanet.org/design-principles-hicks-law-quick-decision-making-3dcc1b1a0632' target='_blank' rel='nofollow'>uxplanet</a>
 
-Understanding Hick's Law - [Youtube](https://www.youtube.com/watch?v=OU7ekX05UEU)
+Understanding Hick's Law - <a href='https://www.youtube.com/watch?v=OU7ekX05UEU' target='_blank' rel='nofollow'>Youtube</a>

--- a/src/templates/Article.jsx
+++ b/src/templates/Article.jsx
@@ -2,8 +2,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
-import Col from 'react-bootstrap/lib/Col';
-import Row from 'react-bootstrap/lib/Row';
 
 import Breadcrumbs from '../templateComponents/Breadcrumbs.jsx';
 
@@ -33,18 +31,10 @@ function Article(props) {
           rel='canonical'
         />
       </Helmet>
-      <Row>
-        <Col xs={ 12 }>
-          <Breadcrumbs path={ pathname } />
-        </Col>
-      </Row>
-      <Row>
-        <Col xs={ 12 }>
-          <div
-            dangerouslySetInnerHTML={{ __html: html }}
-          />
-        </Col>
-      </Row>
+      <Breadcrumbs path={ pathname } />
+      <div
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
I updated the breadcrumb styling.

Before:
![20170926_09-32-48_firefox](https://user-images.githubusercontent.com/7262039/30848322-165617ec-a29f-11e7-95ab-30eb28eb1f90.png)
After:
![20170926_09-29-49_firefox](https://user-images.githubusercontent.com/7262039/30848333-1d4561fc-a29f-11e7-93d4-9a3e2b41465e.png)
After when hovering:
![20170926_09-31-33_firefox](https://user-images.githubusercontent.com/7262039/30848345-2438caf8-a29f-11e7-871d-77dd08a5d3b3.png)

I removed a lot of the spacing around it and added the background back in, in order to both make the content more prominent and separate the breadcrumb.