### PR TITLE
Remove titles from search result descriptions

### DIFF
--- a/src/pageComponents/search/Results.jsx
+++ b/src/pageComponents/search/Results.jsx
@@ -13,7 +13,6 @@ import {
 } from '../../LayoutComponents/search/redux';
 
 const httpRE = /^https?/i;
-const articleMetaRE = /^\-\-\-[\w\W]+?\-\-\-/;
 
 const faNames = {
   challenge: 'free-code-camp',
@@ -69,10 +68,7 @@ class Results extends PureComponent {
   renderResultItems() {
     const { results } = this.props;
     return results.map((result, i) => {
-      const { _index, _source: { body, description, title, url } } = result;
-      const text = body ?
-        body.replace(articleMetaRE, '').slice(0, 141) + '...' :
-        description.slice(0, 141) + '...';
+      const { _index, _source: { title, url }, formattedDescription } = result;
       return (
         <MediaWrapper key={ i } url={ url }>
           <Media>
@@ -85,7 +81,7 @@ class Results extends PureComponent {
             </Media.Left>
             <Media.Body>
               <Media.Heading>{ title }</Media.Heading>
-              <p>{ text }</p>
+              <p>{ formattedDescription }</p>
             </Media.Body>
           </Media>
         </MediaWrapper>


### PR DESCRIPTION
Closes #289 

Before:
![20170926_12-12-08_firefox](https://user-images.githubusercontent.com/7262039/30855273-accc8dfe-a2b4-11e7-9f5f-a8a7d788ae98.png)

After:
![20170926_12-11-36_firefox](https://user-images.githubusercontent.com/7262039/30855281-b194f09c-a2b4-11e7-9505-af1e3d5bbdb6.png)

Maybe the links should be addressed too?
