### PR TITLE
remove explicit references to Ubuntu

### DIFF
--- a/src/pages/linux/index.md
+++ b/src/pages/linux/index.md
@@ -5,6 +5,6 @@ title: Linux
 
 Linux is the most popular operating system in the world. It powers 90% of the world's servers, and is the basis of Google's popular Android operating system.
 
-There are also many versions of Linux designed to be run on personal computers.
+There are also many versions of Linux designed to be run on personal computers, such as Debian or Ubuntu
 
 For more facts about Linux, read Quincy Larson's <a href='https://medium.freecodecamp.org/linux-is-25-yay-lets-celebrate-with-25-rad-facts-about-linux-c8d8ac30076d' target='_blank' rel='nofollow'>"Linux is 25. Yay! Let’s celebrate with 25 stunning facts about Linux"</a>

--- a/src/pages/linux/index.md
+++ b/src/pages/linux/index.md
@@ -5,6 +5,6 @@ title: Linux
 
 Linux is the most popular operating system in the world. It powers 90% of the world's servers, and is the basis of Google's popular Android operating system.
 
-There are also versions of Linux designed to be run on personal computers, such as Ubuntu.
+There are also many versions of Linux designed to be run on personal computers.
 
-For more facts about Ubuntu, read Quincy Larson's <a href='https://medium.freecodecamp.org/linux-is-25-yay-lets-celebrate-with-25-rad-facts-about-linux-c8d8ac30076d' target='_blank' rel='nofollow'>"Linux is 25. Yay! Let’s celebrate with 25 stunning facts about Linux"</a>
+For more facts about Linux, read Quincy Larson's <a href='https://medium.freecodecamp.org/linux-is-25-yay-lets-celebrate-with-25-rad-facts-about-linux-c8d8ac30076d' target='_blank' rel='nofollow'>"Linux is 25. Yay! Let’s celebrate with 25 stunning facts about Linux"</a>


### PR DESCRIPTION
Ubuntu is just one Linux distro. I think it should not get special treatment in the Linux index. Please consider it.
Specially because of this: 
https://www.gnu.org/philosophy/ubuntu-spyware.en.html
https://www.youtube.com/watch?v=CP8CNp-vksc