### PR TITLE
Remove initial expandedState

### DIFF
--- a/src/LayoutComponents/nav/SideNav.jsx
+++ b/src/LayoutComponents/nav/SideNav.jsx
@@ -92,9 +92,8 @@ class SideNav extends Component {
 
     Object.keys(pathMap)
       .map(key => pathMap[key])
-      .map(path => {
+      .forEach(path => {
         this.props.toggleExpandedState(path);
-        return null;
       });
   }
 

--- a/src/LayoutComponents/nav/redux/navigationState.js
+++ b/src/LayoutComponents/nav/redux/navigationState.js
@@ -6,10 +6,4 @@ export const pages = Object.keys(navData)
 export const parents = pages
   .filter(x => x.parent === 'pages');
 
-export let expandedState = pages
-  .reduce((accu, current) => {
-    return {
-      ...accu,
-      [current.path]: false
-    };
-  }, {});
+export const expandedState = {};


### PR DESCRIPTION
I was playing with the profiler again, and I noticed that a _lot_ of time was spent in `src/LayoutComponents/nav/redux/navigationState.js`. A whole lot.
I investigated this, because it seemed odd to me.

I found that it was looping over all of the pages and creating an object for their `expandedState`. This was the culprit. I feel like it maybe have been the `...` not being optimized very well, but I didn't test this. My first test was to replace it `expandedState` an empty object, and that worked. Because `!undefined === true`, everything still works like it did before.

I did some manual testing to confirm whether there was a noticeable improvement. I was surprised by the results.
I tested with the build hosted using `gatsby serve` and wrote down milliseconds spent running scripts using the Chrome profiler. The results:
![20170929_14-02-31_firefox](https://user-images.githubusercontent.com/7262039/31015139-de76e4be-a51e-11e7-83ee-d00bdaed6e71.png)
### 4.5x improvement
This doesn't really impact how fast there is content on your screen, because that HTML is prebuilt, but it does have a big impact on the time to interactive.
