### PR TITLE
Fix breadcrumb rendering on direct link

### DIFF
--- a/src/templateComponents/Breadcrumbs.jsx
+++ b/src/templateComponents/Breadcrumbs.jsx
@@ -12,8 +12,10 @@ function Breadcrumbs(props) {
   if (path === '/') {
     return null;
   }
-  // remove leading '/'
-  const pathMap = path.slice(1)
+
+  const pathMap = path
+    // remove leading and trailing slash
+    .replace(/^\/([a-z0-9/-]+[^/])\/?$/i, '$1')
     .split('/')
     .reduce((accu, current, i, pathArray) => {
       const path = i !== 0 ?
@@ -27,6 +29,7 @@ function Breadcrumbs(props) {
         }
       };
     }, {});
+
   const crumbs = Object.keys(pathMap)
     .map(key => pathMap[key])
     .map((page, i, thisArray) => {


### PR DESCRIPTION
The breadcrumb would break when you linked to an article directly, rather than browsing to it:
![20170929_15-01-26_firefox](https://user-images.githubusercontent.com/7262039/31027086-3c3beb9c-a549-11e7-8733-782fb827ea39.png)
Should be:
![20170929_15-01-48_firefox](https://user-images.githubusercontent.com/7262039/31027120-58e7851c-a549-11e7-9f97-465e86ece2e0.png)
Example: https://guide.freecodecamp.org/html/attributes/

This PR fixes this issue. This was happening because on the live server, a trailing slash was added to each path, while there was none locally. I've switched to using a regex that grabs everything between the first slash and the last one (if there is one), making sure not to include the final slash in what it selects.

I do have one concern about this: my current version only grabs letters, numbers, slashes, and dashes. If there are other characters in the path, it will fail. I could also switch to a version that grabs _everything_, but I'm not sure if we'd want that either.
