### PR TITLE
fix img width in content area

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -69,6 +69,11 @@
 
 .content {
   margin-bottom: 50px;
+
+  img {
+    max-width: 100%;
+    display: block;
+  }
 }
 
 /* NoResults/404 */


### PR DESCRIPTION
Closes #542. Added a nested style to `.content`. Tested locally and works 💯  