### PR TITLE
Fix a bug in python complex number page

### DIFF
--- a/src/pages/python/complex-numbers/index.md
+++ b/src/pages/python/complex-numbers/index.md
@@ -4,47 +4,56 @@ title: Python Complex Numbers
 Complex numbers have a real and an imaginary part, each represented by a floating point number.
 
 The imaginary part of a complex number can be created using an imaginary literal, this results in a complex number with a real part of `0.0`:
-
-    >>> a = 3.5j
-    >>> type(a)
-    <class 'complex'>
-    >>> print(a)
-    3.5j
-    >>> a.real
-    0.0
-    >>> a.imag
-    3.5
+```python
+>>> a = 3.5j
+>>> type(a)
+<class 'complex'>
+>>> print(a)
+3.5j
+>>> a.real
+0.0
+>>> a.imag
+3.5
+```
 
 No literal exists for creating a complex number with non-zero real and imaginary parts. To create a non-zero real part complex number, add an imaginary literal to a floating point number:
 
-    >>> a = 1.1 + 3.5j
-    >>> type(a)
-    <class 'complex'>
-    >>> print(a)
-    (1.1+3.5j)
-    >>> a.real
-    1.1
-    >>> a.imag
-    3.5
+```python
+>>> a = 1.1 + 3.5j
+>>> type(a)
+<class 'complex'>
+>>> print(a)
+(1.1+3.5j)
+>>> a.real
+1.1
+>>> a.imag
+3.5
+```
 
 Or use the <a href='https://docs.python.org/3/library/functions.html#complex' target='_blank' rel='nofollow'>complex constructor</a>.
 
-    class complex([real[, imag]])
+```python
+class complex([real[, imag]])
+```
 
 The arguments used to call the complex constructor can be of numeric (including `complex`) type for either parameter:
 
-    >>> complex(1, 1)
-    (1+1j)
-    >>> complex(1j, 1j)
-    (-1+1j)
-    >>> complex(1.1, 3.5)
-    (1.1+3.5j)
-    >>> complex(1.1)
-    (1.1+0j)
-    >>> complex(0, 3.5)
-    3.5j
+```python
+>>> complex(1, 1)
+(1+1j)
+>>> complex(1j, 1j)
+(-1+1j)
+>>> complex(1.1, 3.5)
+(1.1+3.5j)
+>>> complex(1.1)
+(1.1+0j)
+>>> complex(0, 3.5)
+3.5j
+```
 
 A `string` can also be used as the argument. No second argument is allowed if a string is used as an argument
 
-    >>> complex("1.1+3.5j")
-    (1.1+3.5j)
+```python
+>>> complex("1.1+3.5j")
+(1.1+3.5j)
+```


### PR DESCRIPTION
  * <class 'complex'> was not visible, fixed it
  * Add syntax highlighting

**Before:**
![chrome_2017-09-30_22-56-29](https://user-images.githubusercontent.com/22813027/31051571-211b7c60-a689-11e7-9c82-1c570cdff369.png)

**After:**
![chrome_2017-09-30_23-27-50](https://user-images.githubusercontent.com/22813027/31051576-4b246940-a689-11e7-9753-78251d9f1702.png)

This is my first pull request. So, please bear with me.