### PR TITLE
Update HTML span tag article

### DIFF
--- a/src/pages/html/elements/span-tag/index.md
+++ b/src/pages/html/elements/span-tag/index.md
@@ -6,7 +6,7 @@ title: Span Tag
 The `span` tag is a general purpose element similar to `div`. Browsers do not make any visual changes to `span`s by default, but you can style them with CSS or manipulate them with JavaScript.
 
 ### Example
-```
+```html
 <html>
   <head>
     <title>The Span Tag</title>

--- a/src/pages/html/elements/span-tag/index.md
+++ b/src/pages/html/elements/span-tag/index.md
@@ -3,7 +3,7 @@ title: Span Tag
 ---
 ## Span Tag
 
-The `<span>` is very useful at the time to add some specific elements in the document. It doesn't offer any visual change and when it comes to styling, the manipulation could be done with HTML, CSS, Javascript or jQuery.
+The `span` tag is a general purpose element similar to `div`. Browsers do not make any visual changes to `span`s by default, but you can style them with CSS or manipulate them with JavaScript.
 
 ### Example
 ```
@@ -14,11 +14,16 @@ The `<span>` is very useful at the time to add some specific elements in the doc
   <body>
     <div>
       <p>This is a normal paragraph without any changes.</p>
-      <p>This paragraph has <span style="color:red">red span styling</span> inside it without affect the rest of the document</p>
+      <p>This paragraph has <span style="color:red">red span styling</span> inside it without affecting the rest of the document.</p>
     </div>
   </body>  
 </html>
 ```
 
-#### Differences between <span> and <div>
-Using `<div>` and `<span>` could at first sight not make big differences but when it comes to tags and SEO issues, `<div>` is preferred to use between containers and paragraphs. Meanwhile, `<span>` is preferred to use inside the element.
+The code for the paragraph with red text looks like this:
+```html
+<p>This paragraph has <span style="color:red">red span styling</span> inside it without affecting the rest of the document.</p>
+```
+
+#### Differences between `span` and `div`
+The main difference is that `span` is an inline element, while `div` is a block element. This means that a `span` can appear within a sentence or paragraph (as in the example above), while a `div` will start a new line of content. Note that the CSS `display` property can change this default behavior, but that's way beyond the scope of this article!


### PR DESCRIPTION
I tried to make the wording clearer in a few places. Do you think this is an improvement?

Also, if you take a look at the [current article](https://guide.freecodecamp.org/html/elements/span-tag), there's a lot of extra space in the example. Is there a good way to remove that space and still have the text be red? I think the inline style will get stripped if the whole example isn't wrapped in `<html>` tags.