### PR TITLE
Remove duplicate search page

### DIFF
--- a/src/pages/search.jsx
+++ b/src/pages/search.jsx
@@ -4,14 +4,14 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Helmet from 'react-helmet';
 
-import NoResults from '../../pageComponents/search/NoResults.jsx';
-import NoSupport from '../../pageComponents/search/NoSupport.jsx';
-import Results from '../../pageComponents/search/Results.jsx';
-import ResultsSkeleton from '../../pageComponents/search/ResultsSkeleton.jsx';
+import NoResults from '../pageComponents/search/NoResults.jsx';
+import NoSupport from '../pageComponents/search/NoSupport.jsx';
+import Results from '../pageComponents/search/Results.jsx';
+import ResultsSkeleton from '../pageComponents/search/ResultsSkeleton.jsx';
 
 import {
   resetSearch
-} from '../../LayoutComponents/search/redux';
+} from '../LayoutComponents/search/redux';
 
 const propTypes = {
   isSearching: PropTypes.bool,

--- a/src/pages/search/index.jsx
+++ b/src/pages/search/index.jsx
@@ -1,3 +1,0 @@
-import Search from './Search.jsx';
-
-export default Search;


### PR DESCRIPTION
There were two search pages: `/search` and `/search/Search` (case insensitive).

This PR switches from having a folder with an index and a component to only having a file in the root.