### PR TITLE
Fix gatsby-source-filesystem crashing dev process

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "gatsby-plugin-sitemap": "^1.2.0",
     "gatsby-remark-prismjs": "^1.2.0",
     "gatsby-remark-smartypants": "^1.4.1",
-    "gatsby-source-filesystem": "^1.4.1",
+    "gatsby-source-filesystem": "1.4.10",
     "gatsby-transformer-remark": "^1.6.3",
     "prop-types": "^15.5.10",
     "react": "^15.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,9 +3351,9 @@ gatsby-remark-smartypants@^1.4.1:
     retext-smartypants "^2.0.0"
     unist-util-visit "^1.1.1"
 
-gatsby-source-filesystem@^1.4.1:
-  version "1.4.12"
-  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-1.4.12.tgz#0406da9a2528784cd60b9057af51bd706630e369"
+gatsby-source-filesystem@1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-1.4.10.tgz#710a443e2b07c827f2611344f8bf26e7f0626a22"
   dependencies:
     babel-cli "^6.26.0"
     babel-runtime "^6.26.0"
@@ -5258,9 +5258,13 @@ mime@1.3.x:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
-mime@^1.3.4, mime@^1.3.6:
+mime@^1.3.4:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.0.tgz#69e9e0db51d44f2a3b56e48b7817d7d137f1a343"
+
+mime@^1.3.6:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
 
 mimic-fn@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Every time there was a change in the `src/pages/` directory, gatsby would throw an error and crash the process. I fixed the version to `1.4.10` to fix this

**Tested versions**
Working: `1.0.1` `1.4.1` `1.4.3` `1.4.8` `1.4.10` 
Not working: `1.4.11` `1.4.12` `1.5.1`

Error:
```
C:\Users\Timo\dev\guides\node_modules\gatsby-source-filesystem\gatsby-node.js:50
    reporter.info(`changed file at ${path}`);
            ^

TypeError: Cannot read property 'info' of undefined
    at FSWatcher.<anonymous> (C:\Users\Timo\dev\guides\node_modules\gatsby-source-filesystem\gatsby-node.js:50:13)
    at emitTwo (events.js:125:13)
    at FSWatcher.emit (events.js:213:7)
    at FSWatcher.<anonymous> (C:\Users\Timo\dev\guides\node_modules\chokidar\index.js:196:15)
    at FSWatcher._emit (C:\Users\Timo\dev\guides\node_modules\chokidar\index.js:238:5)
    at FSWatcher.<anonymous> (C:\Users\Timo\dev\guides\node_modules\chokidar\lib\nodefs-handler.js:263:16)
    at FSReqWrap.oncomplete (fs.js:153:5)
```

`1.4.2` was throwing a different error upon starting:
```
⢀ source and transform nodesC:\Users\Timo\dev\guides\node_modules\bluebird\js\release\async.js:61
        fn = function () { throw arg; };
                           ^

ReferenceError: regeneratorRuntime is not defined
    at C:\Users\Timo\dev\guides\node_modules\gatsby-source-filesystem\index.js:8:46
    at Object.<anonymous> (C:\Users\Timo\dev\guides\node_modules\gatsby-source-filesystem\index.js:34:2)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at C:\Users\Timo\dev\guides\node_modules\gatsby\dist\redux\index.js:92:23
    at Promise._execute (C:\Users\Timo\dev\guides\node_modules\bluebird\js\release\debuggability.js:300:9)
    at Promise._resolveFromExecutor (C:\Users\Timo\dev\guides\node_modules\bluebird\js\release\promise.js:483:18)
    at new Promise (C:\Users\Timo\dev\guides\node_modules\bluebird\js\release\promise.js:79:10)
    at exports.loadNodeContent (C:\Users\Timo\dev\guides\node_modules\gatsby\dist\redux\index.js:86:12)
    at Object._callee$ (C:\Users\Timo\dev\guides\node_modules\gatsby-transformer-remark\on-node-create.js:44:20)
    at tryCatch (C:\Users\Timo\dev\guides\node_modules\babel-runtime\node_modules\regenerator-runtime\runtime.js:65:40)
```
