### PR TITLE
[Git section]: fix broken links and inconsistent formatting

### DIFF
--- a/src/pages/git/git-branch/index.md
+++ b/src/pages/git/git-branch/index.md
@@ -14,8 +14,9 @@ Git's branching functionality lets you create new branches of a project to test 
 - [Delete a Branch](#delete-a-branch)
 - [Compare Branches](#compare-branches)
 - [Help with Git Branch](#help-with-git-branch)
+- [More Information](#more-information)
 
-### View Branches
+### View Branches <a name="view-branches"></a>
 To view the branches in a Git repository, run the command:
 ```shell
 git branch
@@ -27,21 +28,21 @@ There are a number of different options you can include with `git branch` to see
 
 You can use the `-a` (or `--all`) option to show the local branches as well as any remote branches for a repository. If you only want to see the remote branches, use the `-r` (or `--remotes`) option.
 
-### Checkout a Branch
+### Checkout a Branch <a name="checkout-a-branch"></a>
 To checkout an existing branch, run the command:
 ```shell
 git checkout BRANCH-NAME
 ```
 
-Generally, Git won't let you checkout another branch unless your working directory is clean, because you would lose any working directory changes that aren't committed. You have three options to handle your changes: 1) trash them (see [Git checkout for details](../git-checkout/index.md)), 2) commit them (see [Git commit for details](../git-commit/index.md)), or 3) stash them (see [Git stash for details](../git-stash/index.md)).
+Generally, Git won't let you checkout another branch unless your working directory is clean, because you would lose any working directory changes that aren't committed. You have three options to handle your changes: 1) trash them (see [Git checkout for details](https://guide.freecodecamp.org/git/git-checkout/)), 2) commit them (see [Git commit for details](https://guide.freecodecamp.org/git/git-commit/)), or 3) stash them (see [Git stash for details](https://guide.freecodecamp.org/git/git-stash/)).
 
-### Create a New Branch
+### Create a New Branch <a name="create-a-new-branch"></a>
 To create a new branch, run the command:
 ```shell
 git branch NEW-BRANCH-NAME
 ```
 
-Note that this command only creates the new branch. You'll need to run `git checkout <newBranchName>` to switch to it.
+Note that this command only creates the new branch. You'll need to run `git checkout NEW-BRANCH-NAME` to switch to it.
 
 There's a shortcut to create and checkout a new branch at once. You can pass the `-b` option (for branch) with `git checkout`. The following commands do the same thing:
 ```shell
@@ -53,9 +54,9 @@ git checkout NEW-BRANCH-NAME
 git checkout -b NEW-BRANCH-NAME
 ```
 
-New branches will include all commits from the parent branch, which is the branch you're on when you create the new branch.
+When you create a new branch, it will include all commits from the parent branch. The parent branch is the branch you're on when you create the new branch.
 
-### Rename a Branch
+### Rename a Branch <a name="rename-a-branch"></a>
 To rename a branch, run the command:
 ```shell
 git branch -m OLD-BRANCH-NAME NEW-BRANCH-NAME
@@ -64,7 +65,7 @@ git branch -m OLD-BRANCH-NAME NEW-BRANCH-NAME
 git branch --move OLD-BRANCH-NAME NEW-BRANCH-NAME
 ```
 
-### Delete a Branch
+### Delete a Branch <a name="delete-a-branch"></a>
 Git won't let you delete a branch that you're currently on. You first need to checkout a different branch, then run the command:
 ```shell
 git branch -d BRANCH-TO-DELETE
@@ -82,17 +83,17 @@ git branch -d --force BRANCH-TO-DELETE
 git branch --delete --force BRANCH-TO-DELETE
 ```
 
-### Compare Branches
+### Compare Branches <a name="compare-branches"></a>
 You can compare branches with the `git diff` command:
 ```shell
 git diff FIRST-BRANCH..SECOND-BRANCH
 ```
 
-You'll see colored output for the changes between branches. For all lines that have changed, the `<secondBranch>` version will be a green line starting with a "+", and the `<firstBranch>` version will be a red line starting with a "-". If you don't want Git to display two lines for each change, you can use the `--color-words` option. Instead, Git will show one line with deleted text in red, and added text in green.
+You'll see colored output for the changes between branches. For all lines that have changed, the `SECOND-BRANCH` version will be a green line starting with a "+", and the `FIRST-BRANCH` version will be a red line starting with a "-". If you don't want Git to display two lines for each change, you can use the `--color-words` option. Instead, Git will show one line with deleted text in red, and added text in green.
 
 If you want to see a list of all the branches that are completely merged into your current branch (in other words, your current branch includes all the changes of the other branches that are listed), run the command `git branch --merged`.
 
-### Help with Git Branch
+### Help with Git Branch <a name="help-with-git-branch"></a>
 If you forget how to use an option, or want to explore other functionality around the `git branch` command, you can run any of these commands:
 ```shell
 git help branch
@@ -100,8 +101,9 @@ git branch --help
 man git-branch
 ```
 
-### Other Resources
-- [Git merge](../git-merge/index.md)
-- [Git checkout](../git-checkout/index.md)
-- [Git commit](../git-commit/index.md)
-- [Git stash](../git-stash/index.md)
+### More Information:  <a name="more-information"></a>
+- The `git merge` command: [fCC Guide](https://guide.freecodecamp.org/git/git-merge/)
+- The `git checkout` command: [fCC Guide](https://guide.freecodecamp.org/git/git-checkout/)
+- The `git commit` command: [fCC Guide](https://guide.freecodecamp.org/git/git-commit/)
+- The `git stash` command: [fCC Guide](https://guide.freecodecamp.org/git/git-stash/)
+- Git documentation: [branch](https://git-scm.com/docs/git-branch)

--- a/src/pages/git/git-clone/index.md
+++ b/src/pages/git/git-clone/index.md
@@ -3,9 +3,9 @@ title: Git Clone
 ---
 ## Git Clone
 
-The Git clone command allows you to copy a remote repository onto your local machine.
+The `git clone` command allows you to copy a remote repository onto your local machine.
 
-First, find the remote repository for the project you're working on or interested in - this can also be your fork of a project. Next, copy the url for it. For example, if you've forked the freeCodeCamp guides repository, the url looks like `https://github.com/<YOUR GITHUB USERNAME>/guides.git`.
+First, find the remote repository for the project you're working on or interested in - this can also be your fork of a project. Next, copy the url for it. For example, if you've forked the freeCodeCamp guides repository, the url looks like `https://github.com/YOUR-GITHUB-USERNAME/guides.git`.
 
 In the command line on your local machine, navigate to where you want to save the project in your working directory. Finally, run the `git clone` command:
 
@@ -19,7 +19,7 @@ The default name of the new directory on your computer is the name of the reposi
 git clone URL-OF-REPOSITORY NAME-OF-DIRECTORY-ON-COMPUTER
 ```
 
-Git gives the remote the alias "origin". This is a useful way to refer to the remote when you want to push your changes to the remote server, or pull changes from it. See [Git push](../git-push/index.md) and [Git pull](../git-pull/index.md) for more details.
+Git gives the remote the alias "origin". This is a useful way to refer to the remote when you want to push your changes to the remote server, or pull changes from it. See [Git push](https://guide.freecodecamp.org/git/git-push/) and [Git pull](https://guide.freecodecamp.org/git/git-pull/) for more details.
 
 Git only pulls the remote's main branch onto your computer. This branch is usually named "master" by convention, but may be defined differently depending on the project.
 

--- a/src/pages/git/git-commit/index.md
+++ b/src/pages/git/git-commit/index.md
@@ -7,14 +7,14 @@ The `git commit` command will save all staged changes, along with a brief descri
 
 Commits are at the heart of Git usage. You can think of a commit as a snapshot of your project, where a new version of that project is created in the current repository. Two important features of commits are:
 
-- you can recall the commited changes at a later date, or revert the project to that version <a href='https://guide.freecodecamp.org/git/git-checkout' target='_blank' rel='nofollow'>see Git checkout</a> 
+- you can recall the commited changes at a later date, or revert the project to that version <a href='https://guide.freecodecamp.org/git/git-checkout' target='_blank' rel='nofollow'>see Git checkout</a>
 - if multiple commits edit different parts of the project, they will not overwrite each other even if the authors of the commit were unaware of each other. This is one of the benefits of using Git over a tool like Dropbox or Google Drive.
 
 ### Options
-There are a number of options that can be included with `git commit`. However, this guide will only cover the two most common options. For an extensive list of options, please consult the <a href='https://git-scm.com/docs/git-commit' target='_blank' rel='nofollow'>Git documentation</a>. 
+There are a number of options that you can include with `git commit`. However, this guide will only cover the two most common options. For an extensive list of options, please consult the <a href='https://git-scm.com/docs/git-commit' target='_blank' rel='nofollow'>Git documentation</a>.
 
 #### The -m Option
-The most common option used with `git commit` is the `-m` option. The `-m` stands for message. When calling `git commit`, it is required to include a message. The message should be a short description of the changes being committed. The message should be at the end of the command and it must be wrapped in quotations `" "`. 
+The most common option used with `git commit` is the `-m` option. The `-m` stands for message. When calling `git commit`, it is required to include a message. The message should be a short description of the changes being committed. The message should be at the end of the command and it must be wrapped in quotations `" "`.
 
 An example of how to use the `-m` option:
 ```shell
@@ -25,16 +25,16 @@ The output in your terminal should look something like this:
 [master 13vc6b2] My message
  1 file changed, 1 insertion(+)
 ```
-**NOTE:** If the `-m` is not included with the `git commit` command you will be prompted to add a message in your default text editor.
+**NOTE:** If the `-m` is not included with the `git commit` command, you will be prompted to add a message in your default text editor.
 
 #### The -a Option
 Another popular option is the `-a` option. The `-a` stands for all. This option automatically stages all modified files to be committed. If new files are added the `-a` option will not stage those new files. Only files that the git repository is aware of will be committed.
 
-For example: 
+For example:
 
-Let’s say that you have a `README.md` file that has already been committed to your repository. If you make changes to this file, you can use the `-a` option in your commit command to stage and add the changes to your repository. However, what if you also added a new file called index.html? The `-a` option will not stage the index.html as it does not currently exist in the repository. When new files have been added, the `git add` command should be invoked in order to stage the files before they can be committed to the repository.
+Let’s say that you have a `README.md` file that has already been committed to your repository. If you make changes to this file, you can use the `-a` option in your commit command to stage and add the changes to your repository. However, what if you also added a new file called `index.html`? The `-a` option will not stage the `index.html` as it does not currently exist in the repository. When new files have been added, the `git add` command should be invoked in order to stage the files before they can be committed to the repository.
 
-An example of how to use the `-a` option: 
+An example of how to use the `-a` option:
 ```shell
 git commit -am “My new changes”
 ```

--- a/src/pages/git/git-push/index.md
+++ b/src/pages/git/git-push/index.md
@@ -3,7 +3,7 @@ title: Git Push
 ---
 ## Git Push
 
-The `git push` is a command that allows you to send the commits from your local branch in your local Git repository to the remote repository.
+The `git push` command allows you to send the commits from your local branch in your local Git repository to the remote repository.
 
 To be able to push to your remote repository, you must ensure that **all your changes to the local repository are committed**.
 

--- a/src/pages/git/git-stash/index.md
+++ b/src/pages/git/git-stash/index.md
@@ -24,9 +24,9 @@ To see what is in your stash, run the command:
 ```shell
 git stash list
 ```
-This returns a list of your saved snapshots in the format `stash@{0}: <branch the stashed changes are for>: <message>`. The `stash@{0}` part is the name of the stash, and the number in the curly braces (`{ }`) is the index of that stash. If you have multiple change sets stashed, each one will have a different index.
+This returns a list of your saved snapshots in the format `stash@{0}: BRANCH-STASHED-CHANGES-ARE-FOR: MESSAGE`. The `stash@{0}` part is the name of the stash, and the number in the curly braces (`{ }`) is the index of that stash. If you have multiple change sets stashed, each one will have a different index.
 
-If you forgot what changes were made in the stash, you can see a summary of them with `git stash show <name of stash>`. If you want to see the typical diff-style patch layout (with the +'s and -'s for line-by-line changes), you can include the `-p` (for patch) option. Here's an example:
+If you forgot what changes were made in the stash, you can see a summary of them with `git stash show NAME-OF-STASH`. If you want to see the typical diff-style patch layout (with the +'s and -'s for line-by-line changes), you can include the `-p` (for patch) option. Here's an example:
 
 ```shell
 git stash show -p stash@{0}
@@ -44,10 +44,10 @@ index 2417dd9..b2c9092 100644
 ### Retrieve Stashed Changes
 To retrieve changes out of the stash and apply them to the current branch you're on, you have two options:
 
-1. `git stash apply <stash name>` applies the changes and leaves a copy in the stash
-2. `git stash pop <stash name>` applies the changes and removes the files from the stash
+1. `git stash apply STASH-NAME` applies the changes and leaves a copy in the stash
+2. `git stash pop STASH-NAME` applies the changes and removes the files from the stash
 
-There may be conflicts when you apply changes. You can resolve the conflicts similar to a merge ([see Git merge for details](../git-merge/index.md)).
+There may be conflicts when you apply changes. You can resolve the conflicts similar to a merge ([see Git merge for details](https://guide.freecodecamp.org/git/git-merge/)).
 
 ### Delete Stashed Changes
 If you want to remove stashed changes without applying them, run the command:
@@ -60,5 +60,6 @@ To clear the entire stash, run the command:
 git stash clear
 ```
 
-### Other Resources
-- [Git merge](../git-merge/index.md)
+### More Information:
+- The `git merge` command: [fCC Guide](https://guide.freecodecamp.org/git/git-merge/)
+- Git documentation: [stash](https://git-scm.com/docs/git-stash)

--- a/src/pages/git/gitignore/index.md
+++ b/src/pages/git/gitignore/index.md
@@ -3,19 +3,19 @@ title: Gitignore
 ---
 ## Gitignore
 
-The .gitignore file is a text file that tells Git which files or folders to ignore in a project.
+The `.gitignore` file is a text file that tells Git which files or folders to ignore in a project.
 
-A local .gitignore file is usually placed in the root directory of a project. You can also create a global .gitignore file and any entries in that file will be ignored in all of your Git repositories.
+A local `.gitignore` file is usually placed in the root directory of a project. You can also create a global `.gitignore` file and any entries in that file will be ignored in all of your Git repositories.
 
-To create a local .gitignore file, create a text file and name it `.gitignore` (remember to include the `.` at the beginning). Then edit this file as needed. Each new line should list an additional file or folder that you want Git to ignore.
+To create a local `.gitignore` file, create a text file and name it `.gitignore` (remember to include the `.` at the beginning). Then edit this file as needed. Each new line should list an additional file or folder that you want Git to ignore.
 
 The entries in this file can also follow a matching pattern.
 
 * `*` is used as a wildcard match
-* `/` is used to ignore pathnames relative to the .gitignore file
-* `#` is used to add comments to a .gitignore file
+* `/` is used to ignore pathnames relative to the `.gitignore` file
+* `#` is used to add comments to a `.gitignore` file
 
-This is an example of what the .gitignore file could look like:
+This is an example of what the `.gitignore` file could look like:
 
 ```
 # Ignore Mac system files
@@ -38,11 +38,9 @@ To add or change your global .gitignore file, run the following command:
 ```bash
 git config --global core.excludesfile ~/.gitignore_global
 ```
-This will create the file `~/.gitignore_global`. Now you can edit that file the same way as a local .gitignore file. All of your Git repositories will ignore the files and folders listed in the global .gitignore file.
+This will create the file `~/.gitignore_global`. Now you can edit that file the same way as a local `.gitignore` file. All of your Git repositories will ignore the files and folders listed in the global `.gitignore` file.
 
-#### More Information:
-<a href='https://git-scm.com/docs/gitignore' target='_blank' rel='nofollow'>Git docs - gitignore</a>
-
-<a href='https://help.github.com/articles/ignoring-files/' target='_blank' rel='nofollow'>GitHub - Ignoring Files</a>
-
-<a href='https://github.com/github/gitignore' target='_blank' rel='nofollow'>GitHub - Useful .gitignore templates</a>
+### More Information:
+- Git documentation: <a href='https://git-scm.com/docs/gitignore' target='_blank' rel='nofollow'>gitignore</a>
+- Ignoring files: <a href='https://help.github.com/articles/ignoring-files/' target='_blank' rel='nofollow'>GitHub</a>
+- Useful `.gitignore` templates: <a href='https://github.com/github/gitignore' target='_blank' rel='nofollow'>GitHub</a>

--- a/src/pages/git/index.md
+++ b/src/pages/git/index.md
@@ -19,15 +19,15 @@ When Git is initialized in a project directory, it begins tracking file changes 
 - [Initialize Git in a Project](#initialize-git-in-a-project)
 - [Get Help in Git](#get-help-in-git)
 - [Sources](#sources)
-- [Other Resources](#other-resources)
+- [More Information](#more-information)
 
-### Understand the Three Sections of a Git Project
+### Understand the Three Sections of a Git Project <a name="understand-the-three-sections-of-a-git-project"></a>
 A Git project will have the following three main sections:
 1. Git directory
 2. Working directory (or working tree)
 3. Staging area
 
-The **Git directory** (located in `<project path>/.git/`) is where Git stores everything it needs to accurately track the project. This includes metadata and an object database which includes compressed versions of the project files.
+The **Git directory** (located in `YOUR-PROJECT-PATH/.git/`) is where Git stores everything it needs to accurately track the project. This includes metadata and an object database which includes compressed versions of the project files.
 
 The **working directory** is where a user makes local changes to a project. The working directory pulls the project's files from the Git directory's object database and places them on the user's local machine.
 
@@ -35,20 +35,20 @@ The **staging area** is a file (also called the "index", "stage", or "cache") th
 
 With three sections, there are three main states that a file can be in at any given time: committed, modified, or staged. You *modify* a file any time you make changes to it in your working directory. Next, it's *staged* when you move it to the staging area. Finally, it's *committed* after a commit.
 
-### Install Git
+### Install Git <a name="install-git"></a>
 You can install Git by visiting the <a href='https://git-scm.com/downloads' target='_blank' rel='nofollow'>Git Downloads page</a> and finding the right version for your operating system.
 
-### Configure the Git Environment
+### Configure the Git Environment <a name="configure-the-git-environment"></a>
 Git has a `git config` tool that allows you to customize your Git environment. You can change the way Git looks and functions by setting certain configuration variables. Run these commands from a command line interface on your machine (Terminal in Mac, Command Prompt or Powershell in Windows).
 
 There are three levels of where these configuration variables are stored:
 1. System: located in `/etc/gitconfig`, applies default settings to every user of the computer. To make changes to this file, use the `--system` option with the `git config` command.
 2. User: located in `~/.gitconfig` or `~/.config/git/config`, applies settings to a single user. To make changes to this file, use the `--global` option with the `git config` command.
-3. Project: located in `<project path>/.git/config`, applies settings to the project only. To make changes to this file, use the `git config` command.
+3. Project: located in `YOUR-PROJECT-PATH/.git/config`, applies settings to the project only. To make changes to this file, use the `git config` command.
 
 If there are settings that conflict with each other, the project-level configurations will override the user-level ones, and the user-level configurations will override the system-level ones.
 
-Note for Windows users: Git looks for the user-level configuration file (`.gitconfig`) in your `$HOME` directory (`C:\Users\$USER`). Git also looks for `/etc/gitconfig`, although it's relative to the MSys root, which is wherever you decide to install Git on your Windows system when you run the installer. If you are using version 2.x or later of Git for Windows, there is also a system-level config file at `C:\Documents and Settings\All Users\Application Data\Git\config` on Windows XP, and in `C:\ProgramData\Git\config` on Windows Vista and newer. This config file can only be changed by `git config -f <file>` as an admin.
+Note for Windows users: Git looks for the user-level configuration file (`.gitconfig`) in your `$HOME` directory (`C:\Users\$USER`). Git also looks for `/etc/gitconfig`, although it's relative to the MSys root, which is wherever you decide to install Git on your Windows system when you run the installer. If you are using version 2.x or later of Git for Windows, there is also a system-level config file at `C:\Documents and Settings\All Users\Application Data\Git\config` on Windows XP, and in `C:\ProgramData\Git\config` on Windows Vista and newer. This config file can only be changed by `git config -f FILE` as an admin.
 
 #### Add Your Name and Email
 Git includes the user name and email as part of the information in a commit. You'll want to set this up under your user-level configuration file with these commands:
@@ -71,12 +71,12 @@ git config --global color.ui true
 
 To see all your configuration settings, use the command `git config --list`.
 
-### Initialize Git in a Project
+### Initialize Git in a Project <a name="initialize-git-in-a-project"></a>
 Once Git is installed and configured on your computer, you need to initialize it in your project to start using its version control powers. In the command line, use the `cd` command to navigate to the top-level (or root) folder for your project. Next, run the command `git init`. This installs a Git directory folder with all the files and objects Git needs to track your project.
 
 It's important that the Git directory is installed in the project root folder. Git can track files in subfolders, but it won't track files located in a parent folder relative to the Git directory.
 
-### Get Help in Git
+### Get Help in Git <a name="get-help-in-git"></a>
 If you forget how any command works in Git, you can access Git help from the command line several ways:
 ```shell
 git help COMMAND
@@ -88,8 +88,8 @@ This displays the manual page for the command in your shell window. To navigate,
 - `b` to page back
 - `q` to quit
 
-### Sources
+### Sources <a name="sources"></a>
 This article uses information from the <a href='https://github.com/progit/progit2' target='_blank' rel='nofollow'>Pro Git</a> book, written by Scott Chacon and Ben Straub and published by Apress. The book is displayed in full in the <a href='https://git-scm.com/book/en/v2' target='_blank' rel='nofollow'>Git documentation</a>.
 
-### Other Resources
-Visit the <a href='https://git-scm.com/' target='_blank' rel='nofollow'>Git official website</a> to find downloads, documentation, and a browser-based tutorial.
+### More Information: <a name="more-information"></a>
+- For downloads, documentation, and a browser-based tutorial: <a href='https://git-scm.com/' target='_blank' rel='nofollow'>Git official website</a>


### PR DESCRIPTION
Some edits to conform the Git section formatting:
- remove angle brackets in all commands
- use the all-caps-with-hyphens style for user-passed parts of a command
- changed the old "Other Resources" section at the bottom to the stub-style "More Information:", changed the layout of those links to match the style I've seen for other sections
- links to other Guide articles weren't working (they were using relative links based on the directory structure), I changed them to direct links to the Guide page and tested that they worked locally

One note, I didn't touch the Git pull section because there's an open PR to potentially edit it 😄 

Closes #874 