### PR TITLE
Add article for JavaScript onclick event

### DIFF
--- a/src/pages/javascript/onclick-event/index.md
+++ b/src/pages/javascript/onclick-event/index.md
@@ -21,7 +21,7 @@ In the simple example above, when a user clicks on the button they will see an a
 The `onclick` event can also be programmatically added to any element using the following code in the following example:
 
 ```javascript
-<p>click on this element.</p>
+<p id="foo">click on this element.</p>
 
 <script>
   var p = document.getElementById("foo"); // Find the paragraph element in the page

--- a/src/pages/javascript/onclick-event/index.md
+++ b/src/pages/javascript/onclick-event/index.md
@@ -35,7 +35,4 @@ The `onclick` event can also be programmatically added to any element using the 
 
 In the above example, when a user clicks on the `paragraph` element in the `html`, they will see an alert showing `onclick Event triggered`. 
 #### More Information:
-<!-- Please add any articles you think might be helpful to read before writing the article -->
-<a href="https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onclick" target="_blank">MDN Documentation for onclick</a>
-
-
+[MDN](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onclick)

--- a/src/pages/javascript/onclick-event/index.md
+++ b/src/pages/javascript/onclick-event/index.md
@@ -2,14 +2,40 @@
 title: Onclick Event
 ---
 ## Onclick Event
+The `onclick` event in JavaScript lets you as a programmer execute a function when an element is clicked. 
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/javascript/onclick-event/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+### Example
+```javascript
+<button onclick="myFunction()">Click me</button>
 
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+<script>
+  function myFunction() {
+    alert('Button was clicked!');
+  }
+</script>
+```
 
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+In the simple example above, when a user clicks on the button they will see an alert in their browser showing `Button was clicked!`. 
 
+### Adding `onclick` dynamically
+The `onclick` event can also be programmatically added to any element using the following code in the following example:
+
+```javascript
+<p>click on this element.</p>
+
+<script>
+  var p = document.getElementById("foo"); // Find the paragraph element in the page
+  p.onclick = showAlert; // Add onclick function to element
+    
+  function showAlert(event) {
+    alert("onclick Event triggered!");
+  }
+</script>
+```
+
+In the above example, when a user clicks on the `paragraph` element in the `html`, they will see an alert showing `onclick Event triggered`. 
 #### More Information:
 <!-- Please add any articles you think might be helpful to read before writing the article -->
+<a href="https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onclick" target="_blank">MDN Documentation for onclick</a>
 
 


### PR DESCRIPTION
Add initial article for `javascript` onclick event, with examples and a link to the MDN documentation for further reading.