### PR TITLE
Fix Typescript Article formatting

### DIFF
--- a/src/pages/typescript/index.md
+++ b/src/pages/typescript/index.md
@@ -7,4 +7,6 @@ TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
 
 Also, it adds static typing functionality to JavaScript.
 
-If you want to try out TypeScript without installation, visit the <a href='http://www.typescriptlang.org/play/index.html' target='_blank' rel='nofollow'>TypeScript Playground</a>. To learn more about installation, see the [Installation Appendix](./src/articles/typescript/appendix-installation/index.md).
+If you want to try out TypeScript without installation, visit the <a href='http://www.typescriptlang.org/play/index.html' target='_blank' rel='nofollow'>TypeScript Playground</a>. 
+
+To learn more about installation, see the [Installation Appendix](./src/articles/typescript/appendix-installation/index.md).

--- a/src/pages/typescript/index.md
+++ b/src/pages/typescript/index.md
@@ -7,6 +7,4 @@ TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
 
 Also, it adds static typing functionality to JavaScript.
 
-T> If you want to try out TypeScript without installation, visit the <a href='http://www.typescriptlang.org/play/index.html' target='_blank' rel='nofollow'>TypeScript Playground</a>.
-T>
-T> To learn more about installation, see the [Installation Appendix](./src/articles/typescript/appendix-installation/index.md).
+If you want to try out TypeScript without installation, visit the <a href='http://www.typescriptlang.org/play/index.html' target='_blank' rel='nofollow'>TypeScript Playground</a>. To learn more about installation, see the [Installation Appendix](./src/articles/typescript/appendix-installation/index.md).


### PR DESCRIPTION
Fix the formatting on the Typescript landing page to remove the `T>` tags shown in the image below:

![image](https://user-images.githubusercontent.com/1348165/31101552-20d8bdb0-a7c6-11e7-8325-753533ddc60e.png)
