### PR TITLE
Add feature to clear the search box on blur event.

### DIFF
--- a/src/LayoutComponents/search/SearchBar.jsx
+++ b/src/LayoutComponents/search/SearchBar.jsx
@@ -42,6 +42,7 @@ class SearchBar extends PureComponent {
     super();
 
     this.handleChange = this.handleChange.bind(this);
+    this.handleBlur = this.handleBlur.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
   }
 
@@ -66,6 +67,11 @@ class SearchBar extends PureComponent {
     updateSearchTerm(value);
   }
 
+  handleBlur(e) {
+    e.preventDefault();
+    updateSearchTerm('');
+  }
+  
   handleSubmit(e) {
     e.preventDefault();
     const { fetchSearchResults } = this.props;
@@ -83,6 +89,7 @@ class SearchBar extends PureComponent {
             <FormControl
               className='input'
               onChange={ this.handleChange }
+              onBlur={ this.handleBlur }
               placeholder='&#xf002; What would you like to know?'
               type='text'
               value={ searchTerm }


### PR DESCRIPTION
Add the function to handle clearing the search box when the focus is not on the search box.

_Edit by @systimotic:_ Closes #232 