### PR TITLE
Fixed broken links in Javascript/Standard Objects/String prototype pages.

### DIFF
--- a/src/pages/javascript/standard-objects/array/array-prototype-lastindexof/index.md
+++ b/src/pages/javascript/standard-objects/array/array-prototype-lastindexof/index.md
@@ -17,7 +17,7 @@ The `lastIndexOf()` method returns the last index at which a given element can b
 
     *   _Optional_. The index at which to start searching backwards. Defaults to the array's length minus one, i.e. the whole array will be searched. If the index is greater than or equal to the length of the array, the whole array will be searched. If negative, it is taken as the offset from the end of the array. Note that even when the index is negative, the array is still searched from back to front. If the calculated index is less than 0, -1 is returned, i.e. the array will not be searched.
 
-<a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf' target='_blank' rel='nofollow'>MDN link</a> | <a href='https://msdn.microsoft.com/en-us/LIBRary/ff679972%28v=vs.94%29.aspx'' target='_blank' rel='nofollow'>MSDN link</a>
+[MDN link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf) | [MSDN link](https://msdn.microsoft.com/en-us/LIBRary/ff679972%28v=vs.94%29.aspx)
 
 ## Returns
 

--- a/src/pages/javascript/standard-objects/string/string-fromcharcode/index.md
+++ b/src/pages/javascript/standard-objects/string/string-fromcharcode/index.md
@@ -5,7 +5,7 @@ The static `String.fromCharCode()` method returns a string created by using the 
 
 ## Syntax
 
-    String.fromCharCode(num1<a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode' target='_blank' rel='nofollow'>, ...[, numN]])
+    String.fromCharCode(num1[, ...[, numN]])
 
 ### Parameters
 
@@ -13,7 +13,7 @@ The static `String.fromCharCode()` method returns a string created by using the 
 
 A sequence of numbers that are Unicode values.
 
-[MDN link</a> | <a href='https://msdn.microsoft.com/en-us/LIBRary/wb4w0k66%28v=vs.94%29.aspx' target='_blank' rel='nofollow'>MSDN link</a>
+[MDN link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode) | [MSDN link](https://msdn.microsoft.com/en-us/LIBRary/wb4w0k66%28v=vs.94%29.aspx)
 
 ## Description
 

--- a/src/pages/javascript/standard-objects/string/string-prototype-concat/index.md
+++ b/src/pages/javascript/standard-objects/string/string-prototype-concat/index.md
@@ -5,11 +5,13 @@ The concat() method combines the text of two or more strings and returns a new s
 
 **Syntax**
 
-    str.concat(string2<a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat' target='_blank' rel='nofollow'>,..., stringN]);
+    str.concat(string2[,..., stringN]);
 
 ## Parameters
 
 **string2...string_N_** The strings which are to be concatenated to this String.
+
+[MDN Link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat)
 
 ## Description
 

--- a/src/pages/javascript/standard-objects/string/string-prototype-slice/index.md
+++ b/src/pages/javascript/standard-objects/string/string-prototype-slice/index.md
@@ -5,7 +5,7 @@ The JavaScript string method `.slice()` extracts a portion of a string and retur
 
 ## Syntax
 
-    str.slice(beginSliceIndex<a href='https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice' target='_blank' rel='nofollow'>, endSliceIndex]);
+    str.slice(beginSliceIndex [, endSliceIndex]);
 
 ## Parameters
 
@@ -16,6 +16,8 @@ The zero-based index where the slice should begin. If beginSliceIndex is a negat
 **endSliceIndex**
 
 Optional. The zero-based index where the slice should end. If omitted, `.slice()` extracts to the end of the string.
+
+[MDN Link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice)
 
 ## Description
 
@@ -38,5 +40,3 @@ Optional. The zero-based index where the slice should end. If omitted, `.slice()
     str.slice(-3);                                  // Returns "ld!"
     str.slice(-3, -1);                              // Returns "ld"
     str.slice(0, -1);                               // Returns "Hello World"
-
-Source [MDN</a>


### PR DESCRIPTION
Addressing issue #367. Few articles in javascript/standard objects/string prototype section had problems with their anchor tags (double quotes, weird misplaced text). Fixed the broken links in the 4 articles listed, using Markdown syntax.