### PR TITLE
added folder for React Native with initial index.md page

### DIFF
--- a/src/pages/react-native/index.md
+++ b/src/pages/react-native/index.md
@@ -1,0 +1,27 @@
+---
+title: React Native
+---
+## React Native
+
+React Native (RN) is a cross-platform tool for building applications that can run outside of the browser — most commonly iOS and Android apps.
+
+** React Native can be used to build applications on Windows devices, desktop OS’s, and Apple TV apps as well but this guide will only be covering it’s most common purpose — Android and iOS applications.
+
+**Table of Contents**
+- [What is React Native?](#what-is-react-native)
+- [Reasons to choose React Native](#reasons-to-choose-react-native)
+
+### What is React Native
+
+RN falls in-between native and hybrid applications on the mobile app spectrum. The user interface is entirely native and overall performance is nearly as good as writing a native app. It also gives you the flexibility to embed web views (webpages) or native code (Java/Kotlin for Android, Objective C/Swift for iOS) inside your applications wherever you want.
+
+It follows the same pattern as React where the views (what you see on the screen) are rendered from the JavaScript files. The difference is that it supplies it’s own API for handling native mobile views vs the DOM on the web. If you are confused about how this works, follow this guide on freeCodeCamp and it will take you step by step through these concepts.
+
+### Reasons to choose React Native
+
+1. Code reusability — It uses one code based that is shared between both platforms.
+1. Reuse web tools and skills — Reuse JavaScript knowledge and tools like Axios, Redux, and other libraries that don’t require the DOM from the web.
+1. Optimized for developer productivity — Comes with features like hot/live reloading and chrome developer tools out of the box!
+1. Performance — Performs better than hybrid application frameworks like Ionic and Cordova.
+1. Corporate backing — Lot’s of companies support and contribute to React Native including Walmart, Airbnb, Wix, and, of course, Facebook.
+1. Community — React Native has a large (and growing) community with over 1500 contributors to the core project and thousands more who contribute to various libraries.


### PR DESCRIPTION
I am adding a section for React Native. I added the initial overview in a `react-native` folder.

**Here is a little of the rest of the articles I am still working on:**
Hello World
View and Text
Component Props (2 challenges)
Component State
Styling with Flexbox
Dimensions
Layouts with Flexbox
Input Fields — Text
Touchables
ScrollView
ListView
Networking with Fetch
Networking with Websockets
Navigator.geolocation API
react-native link
How to add google fonts to your application
Using expo on the web
How to run and build locally using Expo
How to run and build locally using Xcode and Android Studio
How to deploy an application to Google
How to deploy and application to Apple

... plus a few articles about how to use common JS and/or native libraries with React Native