### PR TITLE
Added img-src guide

### DIFF
--- a/src/pages/html/attributes/img-src-attribute/index.md
+++ b/src/pages/html/attributes/img-src-attribute/index.md
@@ -2,14 +2,32 @@
 title: Img Src Attribute
 ---
 ## Img Src Attribute
+The `<img src>` atrribute refers to source of the image you want to display. The img tag is useless without the `src` attribute. It won't display an image. However, if we set the source to something, we can display any image. 
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/html/attributes/img-src-attribute/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+For example, there is an image of the freeCodeCamp Logo located at `https://avatars0.githubusercontent.com/u/9892522?v=4&s=400`
 
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+We can set that as our image using the `src` attribute
 
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+For Instance:
+```
+<html>
+  <head>
+    <title>Img Src Attribute Example</title>
+  </head>
+  <body>
+    <img src="https://avatars0.githubusercontent.com/u/9892522?v=4&s=400">
+  </body>
+</html>
+```
+That Piece of code displays this:
+
+![](https://avatars0.githubusercontent.com/u/9892522?v=4&s=400?raw=true)
 
 #### More Information:
-<!-- Please add any articles you think might be helpful to read before writing the article -->
+- The `src` attribute is supported by all browsers.
+- You can have a locally hosted file as your image as well. E.g `<img src="images/freeCodeCamp.jpeg>`. This would work if you had a folder called images with that image inside in the same file as your `index.html` file.
+
+### Further Reading:
+[HTML.com Explanation](https://html.com/attributes/img-src/)
 
 

--- a/src/pages/html/attributes/img-src-attribute/index.md
+++ b/src/pages/html/attributes/img-src-attribute/index.md
@@ -2,14 +2,15 @@
 title: Img Src Attribute
 ---
 ## Img Src Attribute
-The `<img src>` atrribute refers to source of the image you want to display. The img tag is useless without the `src` attribute. It won't display an image. However, if we set the source to something, we can display any image. 
+The `<img src>` attribute refers to the source of the image you want to display. The `img` tag is useless without the `src` attribute. It won't display an image. However, if you set the source to the location of the image, you can display any image.
 
 For example, there is an image of the freeCodeCamp Logo located at `https://avatars0.githubusercontent.com/u/9892522?v=4&s=400`
 
-We can set that as our image using the `src` attribute
+You can set that as the image using the `src` attribute.
 
-For Instance:
-```
+For example:
+
+```html
 <html>
   <head>
     <title>Img Src Attribute Example</title>
@@ -19,15 +20,12 @@ For Instance:
   </body>
 </html>
 ```
+
 That Piece of code displays this:
 
 ![](https://avatars0.githubusercontent.com/u/9892522?v=4&s=400?raw=true)
 
-#### More Information:
-- The `src` attribute is supported by all browsers.
-- You can have a locally hosted file as your image as well. E.g `<img src="images/freeCodeCamp.jpeg>`. This would work if you had a folder called images with that image inside in the same file as your `index.html` file.
-
-### Further Reading:
-[HTML.com Explanation](https://html.com/attributes/img-src/)
-
-
+### More Information:
+- The `src` attribute is supported by all browsers
+- You can have a locally hosted file as your image as well. For example, `<img src="images/freeCodeCamp.jpeg>` would work if you had a folder called images with that image inside in the same file as your `index.html` file
+- Further reading: [HTML.com](https://html.com/attributes/img-src/)


### PR DESCRIPTION
I added a guide about the img `src` attribute to replace this stub: https://guide.freecodecamp.org/html/attributes/img-src-attribute 