### PR TITLE
Fix forum emoji

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -22,6 +22,7 @@ module.exports = {
       resolve: 'gatsby-transformer-remark',
       options: {
         plugins: [
+          'gatsby-remark-fcc-forum-emoji',
           'gatsby-remark-smartypants',
           'gatsby-remark-prismjs'
         ]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "redux-actions": "^2.2.1",
     "redux-create-types": "0.0.1",
     "redux-epic": "^0.3.0",
-    "rx": "^4.1.0"
+    "rx": "^4.1.0",
+    "unist-util-visit": "^1.1.3"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/plugins/gatsby-remark-fcc-forum-emoji/index.js
+++ b/plugins/gatsby-remark-fcc-forum-emoji/index.js
@@ -1,0 +1,25 @@
+const visit = require('unist-util-visit');
+
+const emojiRE = /^:[a-z_]+:$/;
+
+function markdownToHTML(node) {
+  const { url, title, alt } = node;
+  const html = (
+    `<img src="${url}" title="${title}" alt="${alt}" class="forum-image">`
+  );
+
+  return Object.assign(node, {
+    type: 'html',
+    value: html
+  });
+}
+
+module.exports = ({ markdownAST }) => {
+  visit(markdownAST, 'image', imageNode => {
+    if (emojiRE.test(imageNode.title)) {
+      return markdownToHTML(imageNode);
+    }
+
+    return imageNode;
+  });
+};

--- a/plugins/gatsby-remark-fcc-forum-emoji/package.json
+++ b/plugins/gatsby-remark-fcc-forum-emoji/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "gatsby-remark-fcc-forum-emoji",
+  "description": "A plugin to help fix the styling of forum emoji in the Guide",
+  "main": "index.js"
+}

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -86,6 +86,12 @@
     max-width: 100%;
     display: block;
   }
+
+  img.forum-image {
+    display: inline-block;
+    width: 20px;
+    height: 20px;
+  }
 }
 
 /* NoResults/404 */

--- a/yarn.lock
+++ b/yarn.lock
@@ -8670,7 +8670,7 @@ unist-util-visit-children@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-visit-children/-/unist-util-visit-children-1.1.1.tgz#eba63b371116231181068837118b6e6e10ec8844"
 
-unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.1:
+unist-util-visit@^1.0.0, unist-util-visit@^1.1.0, unist-util-visit@^1.1.1, unist-util-visit@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.1.3.tgz#ec268e731b9d277a79a5b5aa0643990e405d600b"
 


### PR DESCRIPTION
I wrote a Gatsby plugin! 🙌 

The plugin adds a class to any image that was originally an emoji on the forum. The class styles the image to look the way an emoji on the forum looks.

### Before:
![20171009_15-33-41_firefox](https://user-images.githubusercontent.com/7262039/31342519-539176f6-ad0d-11e7-9c99-caeb8f3e9bb6.png)

### After:
![20171009_15-33-31_firefox](https://user-images.githubusercontent.com/7262039/31342523-56f73f92-ad0d-11e7-81f1-0b57a892a588.png)

Related: https://github.com/freeCodeCamp/freeCodeCamp/issues/15918
/cc @nsuchy @Bouncey 
