### PR TITLE
Ethical Breaches: Fixed "more information" links

### DIFF
--- a/src/pages/developer-ethics/ethical-breaches/index.md
+++ b/src/pages/developer-ethics/ethical-breaches/index.md
@@ -13,6 +13,6 @@ There have been a number of well publicized cases in which software was used to 
 
 --
 #### More Information
- <a href='https://medium.freecodecamp.org/dark-genius-how-programmers-at-uber-volkswagen-and-zenefits-helped-their-employers-break-the-law-b7a7939c6591' target='_blank' rel='nofollow'>What do Uber, Volkswagen and Zenefits have in common? They all used hidden code to break the law.</a>
+[What do Uber, Volkswagen and Zenefits have in common? They all used hidden code to break the law] (https://medium.freecodecamp.org/dark-genius-how-programmers-at-uber-volkswagen-and-zenefits-helped-their-employers-break-the-law-b7a7939c6591)
 [10+ things you can do to avoid ethical breaches] (http://www.techrepublic.com/blog/10-things/10-plus-things-you-can-do-to-avoid-ethical-breaches/)
 [Programmers are having a huge discussion about the unethical and illegal things they’ve been asked to do] (http://uk.businessinsider.com/programmers-confess-unethical-illegal-tasks-asked-of-them-2016-11?op=1)


### PR DESCRIPTION
Looks like the post-commit action mangled the links at the bottom. Added proper markdown and line breaks.