### PR TITLE
Remove opening <p> tag for proper display

### DIFF
--- a/src/pages/html/elements/body/index.md
+++ b/src/pages/html/elements/body/index.md
@@ -3,9 +3,9 @@ title: Body
 ---
 ## Body
 <!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
-<p>The  `<body>` tag contains the content for a webpage. Along with `<head>`, it is one of the two required elements of an HTML document. `<body>` must be the second child of an `<html>` element. There can only be one `<body>` element on a page. 
+The `<body>` tag contains the content for a webpage. Along with `<head>`, it is one of the two required elements of an HTML document. `<body>` must be the second child of an `<html>` element. There can only be one `<body>` element on a page.
 
-The `<body>` element should contain all of a page's content, including all display elements. The `<body>` element can also contain `<script>` tags, generally scripts that must be run after a page's content has been loaded.
+The `<body>` element should contain all of a page's content, including all display elements. The `<body>` element can also contain `<script>` tags—generally, scripts that must be run after a page's content has been loaded.
   
   ```html
   <html>

--- a/src/pages/html/elements/body/index.md
+++ b/src/pages/html/elements/body/index.md
@@ -1,23 +1,25 @@
 ---
 title: Body
 ---
+
 ## Body
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
 The `<body>` tag contains the content for a webpage. Along with `<head>`, it is one of the two required elements of an HTML document. `<body>` must be the second child of an `<html>` element. There can only be one `<body>` element on a page.
 
-The `<body>` element should contain all of a page's content, including all display elements. The `<body>` element can also contain `<script>` tags—generally, scripts that must be run after a page's content has been loaded.
-  
-  ```html
-  <html>
-  <head>
-    <title>Document Titles Belong in the Head</title>
-  </head>
-  <body>
-    <p>This paragraph is content. It goes in the body!</p>
-  </body>
-</html>
-  ```
-#### More Information:
-<!-- Please add any articles you think might be helpful to read before writing the article -->
-<a href='https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body' target='_blank' rel='nofollow'> MDN article on &lt;body&gt; </a>
+The `<body>` element should contain all of a page's content, including all display elements. The `<body>` element can also contain `<script>` tags, generally scripts that must be run after a page's content has been loaded.
 
+
+```html
+<html>
+    <head>
+        <title>Document Titles Belong in the Head</title>
+    </head>
+    <body>
+        <p>This paragraph is content. It goes in the body!</p>
+    </body>
+</html>
+```
+
+
+#### More Information:
+[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)


### PR DESCRIPTION
The opening `<p>` tag on line 6 causes code tags to appear incorrectly:

![image](https://user-images.githubusercontent.com/22892219/31559067-f520d9da-b014-11e7-9772-7ff75376219c.png)

After removing the `<p>` tag from line 6, the elements will appear correctly.
