### PR TITLE
Changed typo in Tail Call Optimization Guide and added clarification

### DIFF
--- a/src/pages/software-engineering/tco-tail-call-optimization/index.md
+++ b/src/pages/software-engineering/tco-tail-call-optimization/index.md
@@ -33,7 +33,6 @@ In the previous example, the multiplication operation is executed last in the `r
 
 #### Example
 Here is an example of a JavaScript (ES5) factorial function using recursion **with** TCO.
-This would result in `Infinity` with the `console.log(fact(10000))` call if the code is run in a browser that supports ES6. Else, it would throw an error.
 
 ```javascript
   function fact(n) {
@@ -52,7 +51,7 @@ This would result in `Infinity` with the `console.log(fact(10000))` call if the 
   console.log(fact(10000)); // Infinity - Number too large, but unlike the unoptimized factorial, this does not result in stack overflow.
 ```
 
-Notice that running `fact` on 10000 this time will **not result in a stack overflow** because the call to `factTCO` is the last operation of the function.
+Notice that running `fact` on 10000 this time will **not result in a stack overflow** when *run in a browser that supports ES6* because the call to `factTCO` is the last operation of the function.
 
 ### Why this works
 When the compiler or interpreter notices that the self-call is the last operation of the function, it pops the current function and pushes the self-call to the stack. This way the size of the stack isn't changed. Therefore, the stack doesn't overflow because of the function.

--- a/src/pages/software-engineering/tco-tail-call-optimization/index.md
+++ b/src/pages/software-engineering/tco-tail-call-optimization/index.md
@@ -32,7 +32,8 @@ To solve this using Tail Call Optimization, the statement where the function cal
 In the previous example, the multiplication operation is executed last in the `return x * fact(x-1)` statement, so it was not the final operation of the function. Therefore, it is not tail call optimized. In order for it to be tail call optimized, you need to make the call to itself the last operation of the function.
 
 #### Example
-Here is an example of a JavaScript (ES5) factorial function using recursion **with** TCO:
+Here is an example of a JavaScript (ES5) factorial function using recursion **with** TCO.
+This would result in `Infinity` with the `console.log(fact(10000))` call if the code is run in a browser that supports ES6. Else, it would throw an error.
 
 ```javascript
   function fact(n) {

--- a/src/pages/software-engineering/tco-tail-call-optimization/index.md
+++ b/src/pages/software-engineering/tco-tail-call-optimization/index.md
@@ -32,7 +32,7 @@ To solve this using Tail Call Optimization, the statement where the function cal
 In the previous example, the multiplication operation is executed last in the `return x * fact(x-1)` statement, so it was not the final operation of the function. Therefore, it is not tail call optimized. In order for it to be tail call optimized, you need to make the call to itself the last operation of the function.
 
 #### Example
-Here is an example of a JavaScript (ECMAScript 2015) factorial function using recursion **with** TCO:
+Here is an example of a JavaScript (ES5) factorial function using recursion **with** TCO:
 
 ```javascript
   function fact(n) {


### PR DESCRIPTION
I changed ECMAScript 2015 to ES5 because someone got confused after reading it. 😅 