### PR TITLE
JS/arguments: added clause on ES6 spread

### DIFF
--- a/src/pages/javascript/arguments/index.md
+++ b/src/pages/javascript/arguments/index.md
@@ -65,3 +65,22 @@ for (var i = 0; i < arguments.length; i++) {
 
 For more information on the optimization issues:  
 Optimization Killers: <a href='https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments' target='_blank' rel='nofollow'>Managing Arguments</a>
+
+### ES6 spread operator as a way to circumvent the arguments object
+
+In ES2015/ES6 it is possible to use the spread operator (`...`) instead of the arguments object in most places. Say we have the following function (non-ES6): 
+
+    function getIntoAnArgument() {
+      var args = arguments.slice();
+      args.forEach(function(arg) {
+        console.log(arg);
+      }
+    }
+
+can in ES6 be replaced by: 
+
+    function getIntoAnArgument(...args) {
+        args.forEach(arg => console.log(arg));
+    }
+
+note that we also used an arrow function to shorten the forEach callback!


### PR DESCRIPTION
added a clause at the end on using the ES6 ... spread operator instead of `arguments`. 