### PR TITLE
Can probably be removed

### DIFF
--- a/src/pages/agile/sprint-planning/index.md
+++ b/src/pages/agile/sprint-planning/index.md
@@ -3,7 +3,7 @@ title: Sprint Planning
 ---
 ## Sprint Planning
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/agile/sprint-planning/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+This is a stub.  <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/agile/sprint-planning/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
 
 <a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
 


### PR DESCRIPTION
"sprint planning" and "sprint planning meeting" are pretty much redundant.