### PR TITLE
Docstrings

### DIFF
--- a/src/pages/python/docstrings
+++ b/src/pages/python/docstrings
@@ -1,0 +1,13 @@
+---
+title: Docstrings
+---
+## Docstrings
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/python/docstrings/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+https://docs.python.org/3/tutorial/controlflow.html#documentation-strings


### PR DESCRIPTION
I was writing an article for Python Functions and maybe adding a dedicated docstrings section will be helpful. We use docstrings not only in functions, but in Classes definitions too.