### PR TITLE
Ethical Breaches: Fixed link formatting - fixes #818

### DIFF
--- a/src/pages/developer-ethics/ethical-breaches/index.md
+++ b/src/pages/developer-ethics/ethical-breaches/index.md
@@ -5,14 +5,14 @@ title: Ethical Breaches
 
 There have been a number of well publicized cases in which software was used to deceive users or even break the law. At the heart of these cases is a breach of ethics on the part of one or more developers. Such cases include:
 
-* [**Uber Greyball**] (http://www.businessinsider.com/uber-greyball-app-vtos-authorities-2017-3?op=1) – a tool created by ride-sharing company Uber that collected data from Uber's app to identify and evade officials in multiple cities.
+* [**Uber Greyball**](http://www.businessinsider.com/uber-greyball-app-vtos-authorities-2017-3?op=1) – a tool created by ride-sharing company Uber that collected data from Uber's app to identify and evade officials in multiple cities.
 
-* [**Volkswagon Emission Scandal**] (https://en.wikipedia.org/wiki/Volkswagen_emissions_scandal) – Volkswagen intentionally programmed turbocharged direct injection (TDI) diesel engines to activate some emissions controls only during laboratory emissions testing. The programming caused the vehicles' nitrogen oxide output to meet US standards during regulatory testing but emit up to 40 times more nitrogen oxide in real-world driving.
+* [**Volkswagon Emission Scandal**](https://en.wikipedia.org/wiki/Volkswagen_emissions_scandal) – Volkswagen intentionally programmed turbocharged direct injection (TDI) diesel engines to activate some emissions controls only during laboratory emissions testing. The programming caused the vehicles' nitrogen oxide output to meet US standards during regulatory testing but emit up to 40 times more nitrogen oxide in real-world driving.
 
-* [**Zenefits Insurance Violations**] (http://www.techwire.net/news/zenefits-fined-7-million-for-california-insurance-violations.html) – Former Zenefits CEO, Parker Conrad, crafted a browser extension that allowed its brokers to fake that they had completed a required 52-hour online training course that insurance agents must take to become licensed in California.
+* [**Zenefits Insurance Violations**](http://www.techwire.net/news/zenefits-fined-7-million-for-california-insurance-violations.html) – Former Zenefits CEO, Parker Conrad, crafted a browser extension that allowed its brokers to fake that they had completed a required 52-hour online training course that insurance agents must take to become licensed in California.
 
 --
 #### More Information
- <a href='https://medium.freecodecamp.org/dark-genius-how-programmers-at-uber-volkswagen-and-zenefits-helped-their-employers-break-the-law-b7a7939c6591' target='_blank' rel='nofollow'>What do Uber, Volkswagen and Zenefits have in common? They all used hidden code to break the law.</a>
-[10+ things you can do to avoid ethical breaches] (http://www.techrepublic.com/blog/10-things/10-plus-things-you-can-do-to-avoid-ethical-breaches/)
-[Programmers are having a huge discussion about the unethical and illegal things they’ve been asked to do] (http://uk.businessinsider.com/programmers-confess-unethical-illegal-tasks-asked-of-them-2016-11?op=1)
+* [What do Uber, Volkswagen and Zenefits have in common? They all used hidden code to break the law.](https://medium.freecodecamp.org/dark-genius-how-programmers-at-uber-volkswagen-and-zenefits-helped-their-employers-break-the-law-b7a7939c6591)
+* [10+ things you can do to avoid ethical breaches](http://www.techrepublic.com/blog/10-things/10-plus-things-you-can-do-to-avoid-ethical-breaches/)
+* [Programmers are having a huge discussion about the unethical and illegal things they’ve been asked to do](http://uk.businessinsider.com/programmers-confess-unethical-illegal-tasks-asked-of-them-2016-11?op=1)


### PR DESCRIPTION
Eliminated erroneous space between link title (square brackets) and url (parens) so that links display correctly.
Also updated "More Information" so that it is an unordered list (bullets).

cc: @davcri 