### PR TITLE
Wrap opening paragraph `<br>` in back-ticks

### DIFF
--- a/src/pages/html/elements/br-tag/index.md
+++ b/src/pages/html/elements/br-tag/index.md
@@ -3,7 +3,7 @@ title: Br Tag
 ---
 ## Br Tag
 
-The <br> Tag produces a line break in a text. This is useful for poems and addresses.
+The `<br>` tag produces a line break in a text. This is useful for poems and addresses.
 
 ### Example
 ```html


### PR DESCRIPTION
Without the back-ticks, the `<br>` was functioning as an actual break instead of displaying the html.