### PR TITLE
Formatting in the guide was rendering as html

### DIFF
--- a/src/pages/html/elements/ul-tag/index.md
+++ b/src/pages/html/elements/ul-tag/index.md
@@ -8,7 +8,7 @@ The unordered list (`<ul>`) is a tag used to create bulleted lists. To create a 
 The `<ul>` can be nested inside other lists and is compatible with others tag such as `<a>`,`<p>`,`<button>`, the html styling tags (`<strong>`,`<em>`, etc).
 
 ### Example
-```
+```html
 <html>
   <head>
     <title></title>
@@ -28,4 +28,5 @@ The `<ul>` can be nested inside other lists and is compatible with others tag su
 </html>
 ```
 ## Other Resources
-- The ordered list `<ol>`
+
+- [The ordered list `<ol>` on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol)


### PR DESCRIPTION
The guide page was displaying as html instead of displaying the code. Switched the opening back-ticks to include 'html'