### PR TITLE
Simplification and updates according scrum guide

### DIFF
--- a/src/pages/agile/sprint-backlog/index.md
+++ b/src/pages/agile/sprint-backlog/index.md
@@ -3,12 +3,9 @@ title: Sprint Backlog
 ---
 ## Sprint Backlog
 
-A sprint backlog contains the list of tasks that need to be completed to implement the features planned for a particular Sprint. Ideally, each task in a sprint is relatively short and can be picked up by a team member rather than being assigned.
+The Sprint Backlog is a list of tasks identified by the Scrum Team to be completed during the Scrum Sprint. During the Sprint Planning meeting, the team selects a number of Product Backlog items, usually in the form of user stories, and identifies the tasks necessary to complete each user story. 
 
-The sprint backlog is a list of tasks identified by the Scrum team to be completed during the Scrum sprint. During the sprint planning meeting, the team selects some number of product backlog items, usually in the form of user stories, and identifies the tasks necessary to complete each user story. Most teams also estimate how many hours each task will take someone on the team to complete.
-
-It's critical that the team selects the items and size of the sprint backlog. Because they are the people committing to completing the tasks, they must be the people to choose what they are committing to during the Scrum sprint.
+It is critical that the team itself selects the items and size of the Sprint Backlog. Because they are the people implementing / completing the tasks, they must be the people to choose what they are forecating to achive during the Sprint.
 
 #### More Information:
-https://www.mountaingoatsoftware.com/agile/scrum/scrum-tools/sprint-backlog
-
+<a href="http://www.scrumguides.org/scrum-guide.html#artifacts-sprintbacklog">Scrum Guide: Sprint Backlog</a>


### PR DESCRIPTION
Simplified article by reducing duplication. Purged time estimation, because this has nothing to do with the sprint backlog, but grooming/planning. 

Purged commitment. Current Scrum Guide uses the term forecasting in advance.