### PR TITLE
Removed duplicate link in /javascript/semicolons

### DIFF
--- a/src/pages/javascript/semicolons/index.md
+++ b/src/pages/javascript/semicolons/index.md
@@ -19,9 +19,7 @@ A consistent coding style makes code more readable. Decide whether you will or w
 
 <aside class="onebox whitelistedgeneric">
 
-<header class="source">[blog.izs.me</a></header>
-
-<article class="onebox-body">![](http://assets.tumblr.com/images/og/fb_landscape_share.png)
+<article class="onebox-body">
 
 ### <a href='http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding' target='_blank' rel='nofollow'>An Open Letter to JavaScript Leaders Regarding Semicolons</a>
 


### PR DESCRIPTION
```
[blog.izs.me
![](http://assets.tumblr.com/images/og/fb_landscape_share.png)
```

We already reference blog.izs.me once in the **Other resources** section('An Open Letter to JavaScript Leaders Regarding Semicolons' article) so no need to have those lines in the Other resources section.