### PR TITLE
Removed unnecessary '[' in JS comment

### DIFF
--- a/src/pages/javascript/typeof/index.md
+++ b/src/pages/javascript/typeof/index.md
@@ -10,7 +10,7 @@ The `typeof` operator is useful in JavaScript as it allows programmers to easily
 For example:
 ```javascript
 var x = 12345;    // number
-x = "string"; // string[
+x = "string"; // string
 x = { key: "value" }; // object
 ```
 


### PR DESCRIPTION
'[' has no purpose in this JS comment and could confuse some of the beginners reading the guide.