### PR TITLE
Replaced W3schools resource with MDN

### DIFF
--- a/src/pages/javascript/html-dom/index.md
+++ b/src/pages/javascript/html-dom/index.md
@@ -1,7 +1,7 @@
 ---
-title: HTML Dom
+title: HTML DOM
 ---
-## HTML Dom
+## HTML DOM
 
 With the HTML DOM, JavaScript can access and change all the elements of an HTML document.
 
@@ -23,5 +23,5 @@ With the object model, JavaScript gets all the power it needs to create dynamic 
 
 #### More Information:
 
-[W3C - HTML DOM](https://www.w3schools.com/js/js_htmldom.asp)
+[DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
 


### PR DESCRIPTION
First of all, 'W3C - HTML DOM' is a link title that could confuse beginners to the point where they will think that W3schools website is affiliated with https://www.w3.org/. As it says on https://www.w3schools.com/about/default.asp they have no affiliation with W3.

Also, please see: http://www.w3fools.com/

I've replaced that link with a MDN resource and think that we should stop referencing to that site on all guide articles.