### PR TITLE
Update more information section of body article

### DIFF
--- a/src/pages/html/elements/body/index.md
+++ b/src/pages/html/elements/body/index.md
@@ -22,4 +22,4 @@ The `<body>` element should contain all of a page's content, including all displ
 
 
 #### More Information:
-[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)
+[MDN article on the body tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body)


### PR DESCRIPTION
I went in and added a more specific link in the More Information section of the body tag. Instead of saying just "MDN" it should be more specific and say something along the lines of MDN article on the body tag