### PR TITLE
Added Integration-Rules Article to Replace Stub

### DIFF
--- a/src/pages/mathematics/integration-rules/index.md
+++ b/src/pages/mathematics/integration-rules/index.md
@@ -2,14 +2,30 @@
 title: Integration Rules
 ---
 ## Integration Rules
+As with differentiation, we use a variety of rules when integrating functions. Below are a few of the most common.
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/mathematics/integration-rules/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+**The Constant Rule:**
+&int;k dx = kx + C   where k is a constant
 
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+**The Power Rule:**
+&int; x<sup>n</sup> dx =  + <sup>x<sup>n+1</sup></sup>&frasl;<sub>n+1</sub> + C when n &ne; 1         
 
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+**Exponential Rule:**
+&int; e<sup>kx</sup> dx = <sup>1</sup>&frasl;<sub>kx</sub>  e<sup>kx</sup> + C  where k is a constant
+
+**Trigometric Rules:**
+
+&int; cos(x) dx = sin(x) + C
+
+&int; sin(x) dx = -cos(x) + C
+
+**Sum/Difference Rules:**
+
+&int;[f(x) + g(x)]dx = &int;f(x)dx + &int;g(x)dx
+
+&int;[f(x) - g(x)]dx = &int;f(x)dx - &int;g(x)dx
 
 #### More Information:
-<!-- Please add any articles you think might be helpful to read before writing the article -->
+[Basic Rules with Examples](http://archive.learnhigher.ac.uk/resources/files/Numeracy/Integration_webversion.pdf)
 
-
+[In Depth Guide to Integrals](http://tutorial.math.lamar.edu/pdf/Calculus_Cheat_Sheet_Integrals.pdf)


### PR DESCRIPTION
I created an article with the most common integration rules to replace the existing stub. These are only the basic/common rules, but the linked pages have more complete lists.  The additional rules are harder to type cleanly due to complex fractions. 

I chose to use additional spaces between portions of the formulas so that the different elements are clearer.