### PR TITLE
Fix github Markdown formatting bug

### DIFF
--- a/src/pages/csharp/index.md
+++ b/src/pages/csharp/index.md
@@ -1,7 +1,7 @@
 ---
 title: C#
 ---
-## C#
+## C# #
 
 C Sharp, more commonly referred to as "C#", is a general-purpose, object-oriented programming language. C# was developed by Anders Hejlsberg and his development team at Microsoft and is currently on version 7.0.
 


### PR DESCRIPTION
Currently, the C# page simply renders "C" as the title. This is due to how markdown handles the "#" symbol. This PR will fix the title so that it properly shows up as `C#`

ref: https://stackoverflow.com/questions/32196555/how-to-escape-the-hash-sign-in-a-github-markdown-header-backslash-is-not-w