### PR TITLE
Added Article: Converting am Pm to 24 Hour Clock

### DIFF
--- a/src/pages/mathematics/converting-am-pm-to-24-hour-clock/index.md
+++ b/src/pages/mathematics/converting-am-pm-to-24-hour-clock/index.md
@@ -1,15 +1,46 @@
 ---
 title: Converting am Pm to 24 Hour Clock
 ---
+
 ## Converting am Pm to 24 Hour Clock
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/mathematics/converting-am-pm-to-24-hour-clock/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+In the 12-hour clock format, the 12 hours before midday is 0:00–11:59 **a.m.**, and the 12 hours after midday is 12:00–11:59 **p.m.**. The table below shows how a.m./p.m. time is mapped to 24-hour clock time:
 
-<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+| 12-Hour Clock     | 24-Hour Clock |
+| ----------------- | ------------- |
+| 0:00–11:59 a.m.   | 0:00–11:59    |
+| 12:00–12:59 p.m.  | 12:00-12:59   |
+| 01:00–11:59 p.m.  | 13:00-23:59   |
 
-<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+As such, conversion of a time that falls within the first 13 hours of a day involves simply adding or subtracting the **a.m.** or **p.m.** suffix, and conversion of a time that falls within the latter 11 hours of a day involves an additional operation of either adding or subtracting 12 hours.
 
-#### More Information:
-<!-- Please add any articles you think might be helpful to read before writing the article -->
+### A Note on Leading Zero
 
+Under the 24-hour clock format, a leading zero typically precedes hours that would otherwise be a single digit (for example, 05:00). In contrast, this leading zero is typically not required when using the 12-hour clock format.
+
+### Examples
+
+Converting 12-hour clock time to 24-hour clock time:
+
+```
+6:00 a.m. = 06:00
+
+10:20 a.m. = 10:20
+
+12:30 p.m. = 12:30
+
+1:37 p.m. = (01:37 + 12:00) p.m. = 13:37
+```
+
+Converting 24-hour clock time to 12-hour clock time:
+
+```
+06:30 = 6:30 a.m.
+
+11:30 = 11:30 a.m.
+
+12:00 = 12:00 p.m.
+
+16:35 = (16:35 - 12:00) p.m. = 4:35 p.m.
+```
 


### PR DESCRIPTION
Note that the article title has a consistency issue (am vs. Pm).  In addition, the Latin abbreviations should be formatted as **a.m.** and **p.m.**.

I kept the "incorrect" title in the current commit in favour of not introducing more inconsistencies into the code base, not least because there are systematic issues with article titles that warrant an issue to be raised separately.