### PR TITLE
Add link to Markdown Preview Plus package for Atom

### DIFF
--- a/src/pages/miscellaneous/writing-a-markdown-file-for-github-using-atom/index.md
+++ b/src/pages/miscellaneous/writing-a-markdown-file-for-github-using-atom/index.md
@@ -59,4 +59,4 @@ For contributing to the FreeCodeCamp wiki, go to <a href='https://github.com/Fre
 
 For adding a project or files to GitHub, go to <a href='https://help.github.com/articles/adding-an-existing-project-to-github-using-the-command-line/' target='_blank' rel='nofollow'>this page</a>.
 
-**Bonus step:** Atom has a package named <a href='https://atom.io/packages/markdown-preview-plus' target='_blank' rel='nofollow'>'Markdown Preview Plus'</a>. It does the same as the normal markdown previewer, but the preview file is styled more accurately to the GitHub style. Go ahead and install this package and see what you get.
+**Bonus step:** Atom has a package named <a href='https://atom.io/packages/markdown-preview-plus' target='_blank' rel='nofollow'>Markdown Preview Plus</a>. It does the same as the normal markdown previewer, but the preview file is styled more accurately to the GitHub style. Go ahead and install this package and see what you get.

--- a/src/pages/miscellaneous/writing-a-markdown-file-for-github-using-atom/index.md
+++ b/src/pages/miscellaneous/writing-a-markdown-file-for-github-using-atom/index.md
@@ -59,4 +59,4 @@ For contributing to the FreeCodeCamp wiki, go to <a href='https://github.com/Fre
 
 For adding a project or files to GitHub, go to <a href='https://help.github.com/articles/adding-an-existing-project-to-github-using-the-command-line/' target='_blank' rel='nofollow'>this page</a>.
 
-**Bonus step:** Atom has a package named 'Markdown Preview Plus'. It does the same as the normal markdown previewer, but the preview file is styled more accurately to the GitHub style. Go ahead and install this package and see what you get.
+**Bonus step:** Atom has a package named <a href='https://atom.io/packages/markdown-preview-plus' target='_blank' rel='nofollow'>'Markdown Preview Plus'</a>. It does the same as the normal markdown previewer, but the preview file is styled more accurately to the GitHub style. Go ahead and install this package and see what you get.


### PR DESCRIPTION
Link follows same `target='_blank' rel='nofollow'` pattern as other links and goes to the package's page on `Atom.io`.