### PR TITLE
Add a few stub pages for Redux

### DIFF
--- a/src/pages/redux/redux-actions/index.md
+++ b/src/pages/redux/redux-actions/index.md
@@ -1,0 +1,15 @@
+---
+title: Redux Actions
+---
+## Redux Actions
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/redux/redux-actions/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+

--- a/src/pages/redux/redux-middleware/index.md
+++ b/src/pages/redux/redux-middleware/index.md
@@ -1,0 +1,15 @@
+---
+title: Redux Middleware
+---
+## Redux Middleware
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/redux/redux-middleware/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+

--- a/src/pages/redux/redux-reducers/index.md
+++ b/src/pages/redux/redux-reducers/index.md
@@ -1,0 +1,15 @@
+---
+title: Redux Reducers
+---
+## Redux Reducers
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/redux/redux-reducers/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+

--- a/src/pages/redux/redux-sagas/index.md
+++ b/src/pages/redux/redux-sagas/index.md
@@ -1,0 +1,15 @@
+---
+title: Redux Sagas
+---
+## Redux Sagas
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/redux/redux-sagas/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+

--- a/src/pages/redux/redux-selectors/index.md
+++ b/src/pages/redux/redux-selectors/index.md
@@ -1,0 +1,15 @@
+---
+title: Redux Selectors
+---
+## Redux Selectors
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/redux/redux-selectors/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+

--- a/src/pages/redux/redux-thunk/index.md
+++ b/src/pages/redux/redux-thunk/index.md
@@ -1,0 +1,15 @@
+---
+title: Redux Thunk
+---
+## Redux Thunk
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/redux/redux-thunk/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+

--- a/src/pages/redux/reselect/index.md
+++ b/src/pages/redux/reselect/index.md
@@ -1,0 +1,15 @@
+---
+title: Reselect
+---
+## Reselect
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/redux/reselect/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+
+


### PR DESCRIPTION
I plan to write articles for at least three of these topics (reducers, actions, and reselect). I've added a few stubs for topic ideas that I think people should understand when diving into the redux ecosystem:

- redux sagas
- redux thunk
- redux selectors (not using `reselect` library)
- redux middleware (conceptually)

Hopefully someone else will be able to tackle those four topics, though I may do so myself in the near future. 