### PR TITLE
fix some syntax errors in code examples

### DIFF
--- a/src/pages/javascript/closures/index.md
+++ b/src/pages/javascript/closures/index.md
@@ -13,13 +13,13 @@ function by(propName) {
     }
 }
 
-const person1 = {name: 'joe', height: 72};
-const person2 = {name: 'rob', height: 70};
-const person3 = {name: 'nicholas', height: 66};
+var people = [
+    {name: 'joe', height: 72},
+    {name: 'rob', height: 70},
+    {name: 'nicholas', height: 66},
+];
 
-const arr_ = [person1, person2, person3];
-
-const arr_sorted = arr_.sort(by('height')); // [ { name: 'nicholas', height: 66 }, { name: 'rob', height: 70 },{ name: 'joe', height: 72 } ]
+var sortedPeople = people.sort(by('height')); // [ { name: 'nicholas', height: 66 }, { name: 'rob', height: 70 },{ name: 'joe', height: 72 } ]
 
 ```
 
@@ -46,8 +46,8 @@ Closures are useful because they let you 'remember' data and then let you operat
 Closures can also be used to encapsulate private data/methods. Take a look at this example:
 
 ```javascript
-const bankAccount = (initialBalance) => {
-  const balance = initialBalance;
+function bankAccount(initialBalance) {
+  var balance = initialBalance;
 
   return {
     getBalance: function() {
@@ -60,7 +60,7 @@ const bankAccount = (initialBalance) => {
   };
 };
 
-const account = bankAccount(100);
+var account = bankAccount(100);
 
 account.getBalance(); // 100
 account.deposit(10); // 110
@@ -70,31 +70,35 @@ In this example, we won't be able to access `balance` from anywhere outside of t
 
 <b>Emulating block-scoped variables.</b>
 
-Javascript did not have a concept of block-scoped variables. Meaning that when defining a variable inside a forloop for example, this variable is visible from outside the forloop as well. So how can closures help us solve this problem ? Let's take a look.
+JavaScript did not have a concept of block-scoped variables. In other words, when defining a variable inside a for 
+loop for example, this variable is visible from outside the for loop as well. How can closures help us solve this 
+problem? Let's take a look.
 
 ```javascript
     var funcs = [];
     
-    for(var i = 0; i < 3; i++){
+    for (var i = 0; i < 3; i++) {
         funcs[i] = function(){
             console.log('My value is ' + i);  //creating three different functions with different param values.
         }
     }
     
-    for(var j = 0; j < 3; j++){
+    for (var j = 0; j < 3; j++) {
         funcs[j]();             // My value is 3
                                 // My value is 3
                                 // My value is 3
     }
 ```
 
-Since the variable i does not have block-scope, it's value within all three functions was updated with the loop counter and created malicious values. Closure can help us solve this issue by creating a snapshot of the environment the function was in when it was created, preserving its state.
+Since the variable `i` does not have block-scope, it's value within all three functions was updated with the loop counter and created malicious values. Closure can help us solve this issue by creating a snapshot of the environment the function was in when it was created, preserving its state.
 
 ```javascript
     var funcs = [];
     
-    var createFunction = function(val){
-	    return function() {console.log("My value: " + val);};
+    var createFunction = function(val) {
+	    return function() {
+	        console.log("My value: " + val);
+	    };
     }
 
     for (var i = 0; i < 3; i++) {
@@ -107,8 +111,12 @@ Since the variable i does not have block-scope, it's value within all three func
     }
 
 ```
-The late versions of javascript es6+ have a new keyword called let which can be used to give the variable a blockscope.
-There are also many functions (forEach) and entire libraries (lodash.js) that are dedicated to solve such problems as the ones explained above. They can certainly boost your productivity, however it remains extremely important to have knowledge of all these issues when attempting to create something big.
+The later versions of JavaScript (ES6+) have a new keyword called `let` which can be used to give the variable a 
+block scope.
+
+There are also many functions (Array.forEach) and entire libraries (lodash.js) that are dedicated to solve such 
+problems as the ones explained above. They can certainly boost your productivity, however it remains extremely 
+important to have knowledge of all these issues when attempting to create a large app with many moving parts.
 
 ### More Information:
 


### PR DESCRIPTION
There was an issue with one of the code examples. It used `const balance = ...` and later, `balance += ...`. If run in a terminal, this would throw an error: "Reassignment to const variable."

I have opted to use ES5-compatible syntax over ES6 syntax for ease of use for those who do not know ES6. Additionally, I've named a few variables more appropriately to make it easier for students to visualize. 

Also fixes some minor grammatical errors.