### PR TITLE
Add stubs and more info links to NodeJS page

### DIFF
--- a/src/pages/nodejs/express/index.md
+++ b/src/pages/nodejs/express/index.md
@@ -1,0 +1,13 @@
+---
+title: ExpressJS
+---
+## ExpressJS
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/nodejs/express/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->

--- a/src/pages/nodejs/file-system/index.md
+++ b/src/pages/nodejs/file-system/index.md
@@ -1,0 +1,13 @@
+---
+title: File System
+---
+## File System
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/nodejs/file-system/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->

--- a/src/pages/nodejs/index.md
+++ b/src/pages/nodejs/index.md
@@ -1,0 +1,16 @@
+---
+title: NodeJS
+---
+## NodeJS
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/nodejs/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+[Official NodeJS site](https://nodejs.org)
+[Node Version Manager](https://github.com/creationix/nvm/blob/master/README.md)
+[n: Interactive NodeJS Version Manager](https://github.com/tj/n)

--- a/src/pages/nodejs/npm/index.md
+++ b/src/pages/nodejs/npm/index.md
@@ -1,0 +1,14 @@
+---
+title: NPM
+---
+## NPM
+
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/nodejs/npm/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+
+<a href='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
+
+<!-- The article goes here, in GitHub-flavored Markdown. Feel free to add YouTube videos, images, and CodePen/JSBin embeds  -->
+
+#### More Information:
+<!-- Please add any articles you think might be helpful to read before writing the article -->
+[Official NPM JS Website](https://www.npmjs.com/)


### PR DESCRIPTION
Adds a NodeJS Stub page (with "more info" links to NVM, n, and official NodeJS page). 

Adds stubs for the following concepts within NodeJS:

- Express
- File system
- NPM