### PR TITLE
Side nav a11y updates

### DIFF
--- a/src/LayoutComponents/nav/NavItem.jsx
+++ b/src/LayoutComponents/nav/NavItem.jsx
@@ -12,8 +12,8 @@ const propTypes = {
 function NavItem(props) {
   const { isStubbed, path, title } = props;
   return (
-    <li role='presentation'>
-      <Link role='presentation' to={ path }>
+    <li>
+      <Link to={ path }>
         <span
           className={
             'navItemTitle' +

--- a/src/LayoutComponents/nav/NavPanel.jsx
+++ b/src/LayoutComponents/nav/NavPanel.jsx
@@ -37,7 +37,7 @@ function mapDispatchToProps(dispatch) {
 
 function NoArticles() {
   return (
-    <li role='presentation'>
+    <li>
       <span>
         No articles yet.
         <br />
@@ -109,13 +109,16 @@ class NavPanel extends PureComponent {
   }
 
   render() {
-    const { isExpanded } = this.props;
+    const { isExpanded, title } = this.props;
+    const panelId = `${title.toLowerCase().replace(/\s/g, '-')}-panel`;
     return (
       <Panel
         bsClass='panelStyle panel'
         collapsible={ true }
         expanded={ isExpanded }
         header={ this.renderHeader() }
+        id={ panelId }
+        role='listitem'
         >
         {
           ( isExpanded ? this.renderBody() : null )

--- a/src/LayoutComponents/nav/NavPanel.jsx
+++ b/src/LayoutComponents/nav/NavPanel.jsx
@@ -9,6 +9,7 @@ import { toggleExpandedState } from './redux';
 const propTypes = {
   categoryChildren: PropTypes.arrayOf(PropTypes.string),
   children: PropTypes.any,
+  dashedName: PropTypes.string,
   handleClick: PropTypes.func.isRequired,
   isExpanded: PropTypes.bool,
   path: PropTypes.string,
@@ -19,10 +20,11 @@ function mapStateToProps(state, ownProps) {
   const { path } = ownProps;
   const isExpanded = state.nav.expandedState[path];
   const category = state.nav.pages.filter(page => page.path === path)[0];
-  const { title, children: categoryChildren } = category;
+  const { title, children: categoryChildren, dashedName } = category;
 
   return {
     categoryChildren,
+    dashedName,
     isExpanded,
     title
   };
@@ -109,15 +111,14 @@ class NavPanel extends PureComponent {
   }
 
   render() {
-    const { isExpanded, title } = this.props;
-    const panelId = `${title.toLowerCase().replace(/\s/g, '-')}-panel`;
+    const { isExpanded, dashedName } = this.props;
     return (
       <Panel
         bsClass='panelStyle panel'
         collapsible={ true }
         expanded={ isExpanded }
         header={ this.renderHeader() }
-        id={ panelId }
+        id={ `${dashedName}-panel` }
         role='listitem'
         >
         {

--- a/src/LayoutComponents/nav/SideNav.jsx
+++ b/src/LayoutComponents/nav/SideNav.jsx
@@ -103,15 +103,15 @@ class SideNav extends Component {
     const { expandedState, pages, parents } = this.props;
     const panels = renderPanels(parents, pages);
     return (
-      <div className='sideNav' id='side-nav'>
-        <PanelGroup>
+      <nav className='sideNav' id='side-nav'>
+        <PanelGroup role='list'>
           {
             (!parents || !expandedState) ?
               <NavPanel title='No Parents Here' /> :
               panels
           }
         </PanelGroup>
-      </div>
+      </nav>
     );
   }
 }


### PR DESCRIPTION
## What does this do?
This PR updates the side nav to be keyboard and screen reader friendly for people who depend on assistive technology.

## Change log
- Removes `role="presentation"` as this hides/removes semantic meaning from elements—users need to know they're in a list and how many list items are available
- Adds a unique `id` based on `title` as this generates the `href` attribute in order for links to receive keyboard focus
- Adds `role="list"` and `role="listitem"` for non-semantic elements to convey proper meaning
- Adds `nav` element wrapper in order to provide landmark navigation

## Screens
Everything should look and behave the exact same for sighted mouse users.

<img width="406" alt="screen shot 2017-10-24 at 8 12 43 am" src="https://user-images.githubusercontent.com/1392632/31942408-2b93a8a4-b893-11e7-884f-0b7534cc2fdb.png">

## Related issues

Related to #897.