### PR TITLE
Search input a11y updates

### DIFF
--- a/src/LayoutComponents/search/SearchBar.jsx
+++ b/src/LayoutComponents/search/SearchBar.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Navbar from 'react-bootstrap/lib/Navbar';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import FormControl from 'react-bootstrap/lib/FormControl';
 
 import {
@@ -80,8 +81,15 @@ class SearchBar extends PureComponent {
       <div>
         <form onSubmit={ this.handleSubmit }>
           <Navbar.Form className='formContainer'>
+            <ControlLabel
+              htmlFor='searchInput'
+              srOnly={ true }
+              >
+              Search, press enter to submit
+            </ControlLabel>
             <FormControl
               className='input'
+              id='searchInput'
               onChange={ this.handleChange }
               placeholder='&#xf002; What would you like to know?'
               type='text'

--- a/src/LayoutComponents/search/SearchBar.jsx
+++ b/src/LayoutComponents/search/SearchBar.jsx
@@ -85,7 +85,7 @@ class SearchBar extends PureComponent {
               htmlFor='searchInput'
               srOnly={ true }
               >
-              Search, press enter to submit
+              Search
             </ControlLabel>
             <FormControl
               className='input'


### PR DESCRIPTION
## What does this do?
This PR updates the search `input` for better usability for people who depend on screen reader technology.

## Change log
- Imports `ControlLabel` in order to provide a `label` element for the search `input` control
- Adds a visually hidden `label` to help convey meaning and purpose of the `input` control

## Screens
Everything should look and behave the exact same for sighted mouse users.

<img width="954" alt="screen shot 2017-10-24 at 8 58 10 am" src="https://user-images.githubusercontent.com/1392632/31944279-8114c708-b899-11e7-8353-6af15229f569.png">

## Related issues

Related to #897.