### PR TITLE
Added skip link

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -79,9 +79,12 @@
   border-radius: 0;
 }
 
+.main {
+    outline: 0;
+}
+
 .content {
   margin-bottom: 50px;
-  outline: 0;
 
   img {
     max-width: 100%;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -81,6 +81,7 @@
 
 .content {
   margin-bottom: 50px;
+  outline: 0;
 
   img {
     max-width: 100%;
@@ -258,4 +259,16 @@
   border: none;
   border-radius: 0px;
   cursor: pointer;
+}
+
+.skip-link {
+    background-color: white;
+    left: 0;
+    padding: 5px 10px;
+    top: 0;
+    z-index: 9;
+}
+
+.skip-link:focus {
+    position: absolute;
 }

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -22,10 +22,20 @@ function Layout(props) {
 
   return (
     <div>
-      <Grid fluid={ true }>
+      <Grid
+        fluid={ true }
+        id='header'
+        role='banner'
+        >
         <Row>
           <Navbar className='navBar'>
             <Col md={ 3 } xs={ 12 }>
+              <a
+                className='skip-link sr-only sr-only-focusable'
+                href='#main'
+                >
+                Skip to main content
+              </a>
               <Link
                 className='link'
                 to={ '/' }
@@ -52,7 +62,13 @@ function Layout(props) {
           <Col md={ 4 }>
             <SideNav />
           </Col>
-          <Col className='content' md={ 8 }>
+          <Col
+            className='content'
+            id='main'
+            md={ 8 }
+            role='main'
+            tabIndex='-1'
+            >
             { props.children() }
           </Col>
         </Row>

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -64,12 +64,15 @@ function Layout(props) {
           </Col>
           <Col
             className='content'
-            id='main'
             md={ 8 }
-            role='main'
-            tabIndex='-1'
             >
-            { props.children() }
+              <main
+                className='main'
+                id='main'
+                tabIndex='-1'
+                >
+                { props.children() }
+              </main>
           </Col>
         </Row>
       </Grid>


### PR DESCRIPTION
## What does this do?
This PR adds a "skip to main content" link which is a common feature to skip past repetitive content such as the header and side navigation areas for keyboard users.

## Change log
- Adds additional CSS to present the skip link in an appropriate manner
- Adds a "skip link" above the main logo
- Adds `role="main"` for landmark navigation along with `tabindex="-1"` in order for this element to receive keyboard focus
- Adds `role="banner"` to add additional landmark navigation

## Screens
Skip link only appears on keyboard `:focus`. Everything should look and behave the exact same for sighted mouse users. 

![skip-link](https://user-images.githubusercontent.com/1392632/31948780-c290f5d8-b8a5-11e7-9d94-b20e1c6910ca.gif)

## Related issues

Related to #897.