### PR TITLE
Add polish translation of README.md

### DIFF
--- a/translations/README.pl.md
+++ b/translations/README.pl.md
@@ -7,11 +7,11 @@ To repozytorium jest miejscem, gdzie planujemy i rozwijamy artykuły z freeCodeC
 
 **Spis treści**
 
-- [Czym są artykuły przewodnika freeCodeCamp?](#czym-sa-artykuly-przewodnika-freeCodeCamp)
-- [O czym mogę napisać artykuł?](#o-czym-moge-napisac-artykul)
-- [Jak wnieść wkład?](#how-to-contribute)
-- [Uruchomienie  przewodnika lokalnie na swoim komputerze](#running-the-guide-locally-on-your-own-computer)
-- [Przewodnik po stylu artykułów](#article-style-guide)
+- [Czym są artykuły przewodnika freeCodeCamp?](#czym-są-artykuły-przewodnika-freeCodeCamp)
+- [O czym mogę napisać artykuł?](#o-czym-mogę-napisać-artykuł)
+- [Jak wnieść wkład?](#jak-wnieść-wkład)
+- [Uruchomienie przewodnika lokalnie na swoim komputerze](#uruchomienie-przewodnika-lokalnie-na-swoim-komputerze)
+- [Przewodnik po stylowaniu artykułów](#przewodnik-po-stylowaniu-artykułów)
 - [Licencja](#licencja)
 
 ## Czym są artykuły przewodnika freeCodeCamp?
@@ -49,7 +49,7 @@ Możesz stworzyć PR (Pull Request) ze szkicem artykułu (lub edytować istniej�
 
 Upewnij się, że lokalny fork pozostaje aktualny w stosunku do oficjalnego repozytorium freeCodeCamp guides. Następnym razem kiedy zechcesz wprowadzić zmiany, sprawdź czy lokalna gałąź `master` jest aktualna komendą `git pull --rebase upstream master`, nim zaczniesz tworzyć nowe rozgałęzienia. Powyższa komenda spowoduje pobranie wszystkich zmian wprowadzonych w oficjalnym repozytorium gałęzi `master` bez tworzenia dodatkowego commita w twoim lokalnym repozytorium.
 
-## Running the Guide locally on your own computer
+## Uruchomienie przewodnika lokalnie na swoim komputerze
 
 Finally, if you want to run a version of the guides repository locally, follow these steps:
 
@@ -65,19 +65,19 @@ yarn run dev
 
 In this project, we are using `yarn` because `netlify` builds our site with `yarn`.
 
-## Article style guide
+## Przewodnik po stylowaniu artykułów
 
 We've written the following guide to writing Guide articles to help you get started contributing.
 
-**Table of Contents**
+**Spis treści**
 
-- [Article title](#article-title)
-- [Modularity](#modularity)
-- [General writing tips](#general-writing-tips)
-- [Formatting example code](#formatting-example-code)
-- [Adding images to articles](#adding-images-to-articles)
-- [Proper nouns](#proper-nouns)
-- [Where to get help](#where-to-get-help)
+- [Tytuł artykułu](#tytuł-artykułu)
+- [Modułowość](#modułowość)
+- [Pisanie artykułów](#pisanie-artykułów)
+- [Formatowanie przykładowego kodu](#formatowanie-przykładowego-kodu)
+- [Dodawanie obrazów do artykułów](#dodawanie-obrazów-do-artykułów)
+- [Właściwe rzeczowniki](#właściwe-rzeczowniki)
+- [Gdzie otrzymać pomoc](#gdzie-otrzymać-pomoc)
 
 
 ### Tytuł artykułu
@@ -108,7 +108,7 @@ We can reference other articles by linking to them inline, or in an "Other Resou
 
 Our goal is to have thousands of articles that cover a broad range of technical topics.
 
-### General writing tips
+### Pisanie artykułów
 
 Before you begin writing, create an outline of the topic and think about any coding examples you'll use (if applicable). This helps to organize your thoughts and make the writing process easier.
 
@@ -213,7 +213,7 @@ Proper nouns should use correct capitalization when possible. Below is a list of
 
 Front-end development (adjective form with a dash) is when you working on the front end (noun form with no dash). The same goes with the back end, full stack, and many other compound terms.
 
-### Where to get help
+### Gdzie otrzymać pomoc
 
 Technical writing, or the literature of science and technology, is hard. You'll need to take a technical (usually abstract) topic and explain it in a clear, accurate, and objective manner. You'll likely go through several rounds of proofreading and editing before you're happy with the result.
 

--- a/translations/README.pl.md
+++ b/translations/README.pl.md
@@ -13,6 +13,7 @@ To repozytorium jest miejscem, gdzie planujemy i rozwijamy artykuły z freeCodeC
 - [Uruchomienie przewodnika lokalnie na swoim komputerze](#uruchomienie-przewodnika-lokalnie-na-swoim-komputerze)
 - [Przewodnik stylowania artykułów](#przewodnik-stylowania-artykułów)
 - [Licencja](#licencja)
+- [Informacje od tłumacza](#informacje-od-tłumacza)
 
 ## Czym są artykuły przewodnika freeCodeCamp?
 Artykuły przewodnika mogą dotyczyć składni, wzorców projektowania, tego czym są aria labels, lub informacje na temat znaczenia numerów w prawym górnym rogu ekranu na stronie freecodecamp.org. Tutaj znajdziesz [przykład artykułu o tagach HTML](./src/pages/html/elements/index.md).
@@ -20,7 +21,7 @@ Artykuły przewodnika mogą dotyczyć składni, wzorców projektowania, tego czy
 ## O czym mogę napisać artykuł?
 Twoja pomoc w tworzeniu artykułów jest mile widziana. Nie musisz być ekspertem w danej dziedzinie aby o niej napisać - ten przewodnik jest tworzony na zasadach open source, więc nawet jeśli zrobisz błąd, inna osoba prędzej czy później go poprawi.
 
-Aby pomóc, znajdź `stub article` (`trzon artykułu`) na [stronie przewodnika](https://guide.freecodecamp.org/), napisz artykuł, nastpnie stwórz pull request (PR) aby zastąpić trzon twoimi zmianami.
+Aby pomóc, znajdź `trzon artykułu` (`stub article`) na [stronie przewodnika](https://guide.freecodecamp.org/), napisz artykuł, nastpnie stwórz pull request (PR) aby zastąpić trzon twoimi zmianami.
 
 Jeśli nie możesz znaleźć trzonu na temat który cię interesuje, możesz wykonać PR który go stworzy (wraz ze szkicem artykułu). Zapraszamy do zadawania pytań jeśli nie jesteś pewien/a, gdzie w strukturze katalogów należy umieścić nowy wpis.
 
@@ -39,7 +40,7 @@ Możesz stworzyć PR (Pull Request) ze szkicem artykułu, lub edytować istniej�
 - Na następnym ekranie, dodaj dodatkowe szczegóły na temat swojego PR i kliknij przycisk "Create pull request"
 
 
-2) Jeśli preferujesz tworzyć zmiany lokalnie na swoim komputerze przed wysłaniem PR, postępuj zgodnie z instrukcją:
+2) Jeśli preferujesz tworzyć zmiany lokalnie na swoim komputerze, postępuj zgodnie z instrukcją:
 - Wykonaj Fork tego repozytorium
 - Skopiuj repozytorium na dysk lokalny uruchamiając komendę `git clone https://github.com/TWOJA-NAZWA-UZYTKOWNIKA-GITHUB/guides.git`
 - Dodaj remote upstream uruchamiając komendę `git remote add upstream https://github.com/freeCodeCamp/guides.git`, aby git wiedział gdzie znajduje się oficjalne repozytorium freeCodeCamp guides.
@@ -82,82 +83,82 @@ Napisaliśmy poniższy poradnik pisania artykułów, aby pomóc ci rozpocząć t
 
 ### Tytuł artykułu
 
-Article titles should be as short, concise, and to-the-point as possible. We want campers to quickly find the information they're looking for, and the title should reflect the main theme of the article.
+Tytuły artykułów powinny być tak krótkie, zwięzłe i dokładne jak to tylko możliwe. Chcemy, aby użytkownicy szybko znaleźli informacje, których szukają. Tytuł powinien odzwierciedlać główny temat artykułu.
 
-Here are some title examples:
+Kilka przykładowych tytułów artykułów:
 
 - "HTML Lists"
 - "CSS Borders"
 - "JavaScript For Loop"
 
-The folder name is used in the URL, so only use dashes `-`, numbers `0-9`, and lowercase letters `a-z` for it.
+Nazwa folderu jest wykorzystywana w URL, więc do jej tworzenia używaj tylko dashy (dashes) `-`, numerów `0-9`, oraz małych liter `a-z`.
 
-Here are some folder name examples:
+Kilka przykładowych nazw folderów:
 
 - html-lists
 - css-borders
 - javascript-for-loop
 
-However, you can include special characters in the article title.
+Możesz jednak wykorzystywać znaki specjalne w tytułach artykułów.
 
 ### Modułowość
 
-Each article should explain exactly one concept, and that concept should be apparent from the article's title.
+Każdy artykuł powinien wyjaśniać dokładnie jeden koncept i powinien on jasno wynikać z tytuły artykułu.
 
-We can reference other articles by linking to them inline, or in an "Other Resources" section at the end of the article.
+Można odnosić się do innych artykułów poprzez linkowanie do nich w treści, lub w sekcji "Other Resources" na końcu artykułu.
 
-Our goal is to have thousands of articles that cover a broad range of technical topics.
+Naszym celem jest stworzenie tysięcy artykułów, obejmujących szeroki zakres tematów technicznych.
 
 ### Pisanie artykułów
 
-Before you begin writing, create an outline of the topic and think about any coding examples you'll use (if applicable). This helps to organize your thoughts and make the writing process easier.
+Przed rozpoczęciem pisania, stwórz zarys tematu i zastanów się nad fragmentami kodu, które wykorzystasz jako przykłady (jeśli dotyczy). Ten proces pomaga uporządkować myśli i ułatwia pisanie.
 
-Articles should be written with short, clear sentences, and use as little jargon as necessary. All jargon should be defined immediately in plain English.
+Artykuły powinny być napisane krótkimi, jasnymi zdaniami i używać jak najmniej żargonu jak to możliwe. Wszystkie pojęcia będące żargonem powinny zostać wyjaśnione jak najszybciej prostym językiem.
 
-The introduction paragraph should only be 1-2 sentences long and be a simple explanation of the main topic. It should limit the use of any links to other Guide articles, as they can be distracting.
+Pierwszy akapit powinien mieć długość 1-2 zdań i być prostym wyjaśnieniem głównego tematu z pominięciem linków do innych artykułów, ponieważ mogą one rozpraszać.
 
-Keep paragraphs short (around 1-4 sentences). People are more likely to read several short paragraphs over a wall of text.
+Staraj się tworzyć krótkie akapity (około 1-4 zdań). Istnieje większe prawdopodobieństwo, że użytkownicy przeczytają kilka krótkich akapitów niż ścianę tekstu.
 
-Use active voice instead of passive voice. Generally, it's a stronger and more straightforward way to communicate a subject. For example:
-  - (Passive) The `for` loop in JavaScript is used by programmers to...
-  - (Active) Programmers use the `for` loop in JavaScript to...
+Stosuj tryb aktywny zamiast pasywnego. Ogólnie rzecz biorąc jest jest to silniejszy i bardziej bezpośredni sposób komunikowania się. Na przykład: 
+  - (Pasywny) Pętla `for` w JavaScript jest używana przez programistów do...
+  - (Aktywny) Programiści używają pętli `for` w JavaScript do...
 
-If you want to abbreviate a term in your article, write it out fully first, then put the abbreviation in parentheses. For example, "In computer science, an abstract syntax tree (AST) is ..."
+Jeśli chcesz zastosować skrót terminu w swoim artykule, najpierw napisz go w całości, a następnie skrót umieść w nawiasie. Na przykład: "In computer science, an abstract syntax tree (AST) is ..."
 
-Text should use the second person ("you") to help to give it a conversational tone. This way, the text and instructions seem to speak directly to the camper reading it. Try to avoid using the first person ("I", "we", "let's", and "us").
+Tekst powinien używać drugiej osoby liczby pojedynczej ("you"), aby nadać mu styl konwersacji. Dzięki temu tekst i instrukcje w nim zawarte wydają się mówić bezpośrednio do czytelnika. Staraj się unikać używania pierwszej osoby ("I", "we", "let's", and "us").
 
-If there are other Guide resources you think campers would benefit from, add them at the bottom in an "Other Resources" section.
+Jeśli uważasz, że są inne zasoby przewodnika, z których użytkownicy powinni skorzystać, dodaje je na dole w sekcji "Other Resources".
 
-You can add diagrams, graphics, or visualizations as necessary. You can also embed relevant YouTube videos and interactive [REPL.it](https://repl.it/) code editors.
+W razie potrzeby możesz dodać diagramy, grafiki lub wizualizacje., a także umieścić adekwatne filmy YouTube i interaktywne edytory kodu [REPL.it](https://repl.it/).
 
-Don't use emojis or emoticons in the Guide. freeCodeCamp has a global community, and the cultural meaning of an emoji or emoticon may be different around the world. Also, emojis can render differently on different systems.
+Nie używaj emoji ani emotikon w przewodniku. freeCodeCamp to globalna społeczność i kulturowe znaczenie emoji lub emotikony może się różnić na całym świecie. Ponadto, emoji mogą wyświetlać się inaczej na różnych systemach.
 
-Use double quotes where applicable.
+W stosownych przypadkach użyj cudzysłowów (double quotes).
 
-Format language keywords as code - this is done with the backtick key (located to the left of the "1" key on a US keyboard) in GitHub-flavored markdown. For example, put backticks around HTML tag names or CSS property names.
+Formatuj słowa kluczowe za pomocą języka markdown GitHub jako kod - odbywa się to za pomocą odwróconych apostrofów (klawisz backtick umieszczony po lewej stronie klawisza "1" na klawiaturze). Na przykład, umieść odwrócone apostrofy (backticki) wokół nazwy tagu HTML lub nazwy właściwości CSS.
 
-Use the Oxford Comma when possible (it is a comma used after the penultimate item in a list of three or more items, before ‘and’ or ‘or’ e.g. an Italian painter, sculptor, and architect). It makes things easier, clearer, and prettier to read.
+W miarę możliwości stosuj przecinek oxfordzki (Oxford Comma). Jest to przecinek stosowany po przedostatnim elemencie podczas listowania trzech lub więcej elementów, przed słowami ‘and’ lub ‘or’, na przykład: an Italian painter, sculptor, and architect. Powoduje to, że tekst jest łatwiejszy od czytania, bardziej czytelny i ładniejszy dla oka.
 
 ### Atrybucja
 
-To minimize the potential for plagiarism and maintain integrity in these guides, it is important to give credit where necessary. Any material quoted, or used directly and unchanged, from source material should be wrapped in quotation marks and be adequately cited. Material that is not a direct quote but is still paraphrased from a different resource should also be cited. You can create superscript numerals to mark content that is cited using `<sup></sup>` tags. Like so: <sup>1</sup>
+Aby zminimalizować ryzyko plagiatu i zachować integralność w artykułach przewodnika, ważne jest, aby w razie potrzeby podać autora lub źródło cytowanego materiału. Jesli materiał cytowany jest w postaci niezmienionej w stosunku domateriału źródłowego, powinien być umieszczony w cudzysłowie i zawierać odpowiedni przypis. Materiał, który nie jest bezpośrednim cytatem, ale wciąż parafrazuje inne zasoby, należy również oznaczyć. W tym celu mozna użyc cyfr górnego indeksu (superscript) przy użyciu tagów `<sup></sup>` w następujący sposób <sup>1</sup>
 
-Then, at the bottom of your article, place a `### Sources` heading and include all of your citations numbered to correspond with your marks above:
+Następnie na dole artykułu należy umieść nagłówek `### Sources` i dołączyć listę wszystkich cytatów, które powinny odpowiadać oznaczeniom powyżej:
 
 <blockquote>
-Here is some content that should be cited.<sup>1</sup> And here is even more that should be cited from another source.<sup>2</sup>
+Tu jest treść, która powinna zostać oznaczona jako cytat.<sup>1</sup> A tu jest jeszcze więcej treści która powinna być oznaczona jako cytat z innego źródła.<sup>2</sup>
 
 ### Źródła
 1. [Doe, John. "Authoring Words." *WikiCoder*. January 1, 1970. Accessed: October 20, 2017](#)
 2. [Purdue OWL Staff. "MLA Works Cited: Electronic Sources." *Purdue Online Writing Lab.* October 12, 2017. Accessed: Ocotber 20, 2017.](https://owl.english.purdue.edu/owl/resource/747/08/)
 </blockquote>
-You can check out the Purdue link above to see how to properly cite web sources (they even show how to cite tweets!). Typically, an attribution has a structure like the following:
+Możesz sprawdzić link "Purdue" powyżej, aby zobaczyć, jak prawidłowo cytować źródła internetowe (wyjaśniają nawet, jak cytować tweety!). Zazwyczaj przypis ma strukturę podobną do następującej:
 
->Author Last Name, Author First Name. "Article Title." *Publication.* Publisher. Date Published. Date Accessed.
+>Nazwisko autora, Imię autora. "Tytuł artykułu." *Publikacja.* Wydawca. Data wydania. Date dostępu.
 
-If you cannot find an author or published date, which is common, simply omit these.
+Jeśli nie możesz znaleźć autora lub daty wydania, co jest dość powszechne, po prostu pomiń je.
 
-Use of proper citations will not only keep the guides reputable, but these citations and links will also provide valuable resources should the reader want to learn more about the topic. Also note that instances of blatant plagiarism will be either removed or have their pull requests declined, and the user will receive a warning. Please refer to and review the [Academic Honesty Policy](https://www.freecodecamp.org/academic-honesty) before contributing.
+Korzystanie z odpowiednio sformatowanych cytatów nie tylko utrzymuje dobrą reputację przewodnika, ale także poprzez linki pozwala dostarczyć wartościowych zasobów, które pozwolą czytelnikowi dowiedzić się więcej na temat danego zagadnienia. Należy również zauważyć, że w przypadku plagiatu treści zostaną usunięte lub pull requesty zostaną odrzucone, a użytkownik otrzyma ostrzeżenie. Przed wniesieniem wkładu w treść przewodnika zapoznaj się z [Academic Honesty Policy](https://www.freecodecamp.org/academic-honesty).
 
 ### Formatowanie przykładowego kodu
 
@@ -233,6 +234,16 @@ Z twoją pomocą, możemy stworzyć kompleksowe narzędzie referencyjne, które 
 
 Copyright (c) 2017 freeCodeCamp.
 
-Zawartość tego repozytorium podlega pod nastepujące licencje:
-- The computer software is licensed under the [BSD-3-Clause](./LICENSE.md).
-- The reference content as in ./src/pages and subdirectories is licensed under the [CC-BY-SA-4.0](./LICENSE-freeCodeCamp-Guide-Articles.md).
+Zawartość tego repozytorium podlega pod następujące licencje:
+- Licencja oprogramowania komputerowego (software) to [BSD-3-Clause](./LICENSE.md).
+- Licencja zawartości przewodnika w ./src/pages i w podfolderach to [CC-BY-SA-4.0](./LICENSE-freeCodeCamp-Guide-Articles.md).
+
+## Informacje od tłumacza
+
+Powyższe tłumaczenie ma za zadanie ułatwić pierwszy kontakt z przewodnikiem freeCodeCamp osobom, które na codzień komunikują się w języku polskim. Aktualnie artykuły przewodnika freeCodeCamp (freeCodeCamp Guide) tworzone są tylko i wyłącznie w języku angielskim i w tym języku należy dokonywać ewentualnych kontrybucji.
+
+W powyższym pliku README:
+- Pojawiły się terminy związane z obszarem computer science. Zostały one przetłumaczone tylko w tym miejscu gdzie nei budziały wątpliwości
+- Pojawiły się terminy związane z interfejsem i termonologią GitHub. W większości przypadków nie zostały one przetłumaczone, z wyjątkiem terminu "branch", który w języku polskim powszechnie wystepuje jako "gałąź"
+- Pojawił się termin "stub article", który tłumaczony dosłownie oznacza "kikut artykułu" co w języku polskim nie oddaje prawidłowo znaczenia sensu tej struktury. Z tego powodu zamiast wymienionego wyżej zwrotu zastosowany został termin "trzon"
+- W sekcji "General writing tips" zachowana została oryginalna forma pisowni osób i zwrotów w języku angielskim tam, gdzie zworty te wyjasniały w jaki sposób należy pisać artykuły

--- a/translations/README.pl.md
+++ b/translations/README.pl.md
@@ -141,9 +141,9 @@ W miarę możliwości stosuj przecinek oxfordzki (Oxford Comma). Jest to przecin
 
 ### Atrybucja
 
-Aby zminimalizować ryzyko plagiatu i zachować integralność w artykułach przewodnika, ważne jest, aby w razie potrzeby podać autora lub źródło cytowanego materiału. Jesli materiał cytowany jest w postaci niezmienionej w stosunku domateriału źródłowego, powinien być umieszczony w cudzysłowie i zawierać odpowiedni przypis. Materiał, który nie jest bezpośrednim cytatem, ale wciąż parafrazuje inne zasoby, należy również oznaczyć. W tym celu mozna użyc cyfr górnego indeksu (superscript) przy użyciu tagów `<sup></sup>` w następujący sposób <sup>1</sup>
+Aby zminimalizować ryzyko plagiatu i zachować integralność w artykułach przewodnika ważne jest, aby w razie potrzeby podać autora lub źródło cytowanego materiału. Jeśli materiał cytowany jest w postaci niezmienionej w stosunku do materiału źródłowego, powinien być umieszczony w cudzysłowie i zawierać odpowiedni przypis. Materiał który nie jest bezpośrednim cytatem, ale wciąż parafrazuje inne zasoby, należy również oznaczyć. W tym celu można użyć cyfr górnego indeksu (superscript) przy użyciu tagów `<sup></sup>` w następujący sposób <sup>1</sup>
 
-Następnie na dole artykułu należy umieść nagłówek `### Sources` i dołączyć listę wszystkich cytatów, które powinny odpowiadać oznaczeniom powyżej:
+Następnie na dole artykułu należy umieścić nagłówek `### Sources` i dołączyć listę wszystkich cytatów, które powinny odpowiadać oznaczeniom powyżej:
 
 <blockquote>
 Tu jest treść, która powinna zostać oznaczona jako cytat.<sup>1</sup> A tu jest jeszcze więcej treści która powinna być oznaczona jako cytat z innego źródła.<sup>2</sup>
@@ -158,21 +158,21 @@ Możesz sprawdzić link "Purdue" powyżej, aby zobaczyć, jak prawidłowo cytowa
 
 Jeśli nie możesz znaleźć autora lub daty wydania, co jest dość powszechne, po prostu pomiń je.
 
-Korzystanie z odpowiednio sformatowanych cytatów nie tylko utrzymuje dobrą reputację przewodnika, ale także poprzez linki pozwala dostarczyć wartościowych zasobów, które pozwolą czytelnikowi dowiedzić się więcej na temat danego zagadnienia. Należy również zauważyć, że w przypadku plagiatu treści zostaną usunięte lub pull requesty zostaną odrzucone, a użytkownik otrzyma ostrzeżenie. Przed wniesieniem wkładu w treść przewodnika zapoznaj się z [Academic Honesty Policy](https://www.freecodecamp.org/academic-honesty).
+Korzystanie z odpowiednio sformatowanych cytatów nie tylko utrzymuje dobrą reputację przewodnika, ale także poprzez linki pozwala dostarczyć wartościowych zasobów, które pozwolą czytelnikowi dowiedzieć się więcej na temat danego zagadnienia. Należy również zauważyć, że w przypadku plagiatu treści zostaną usunięte lub pull requesty zostaną odrzucone, a użytkownik otrzyma ostrzeżenie. Przed wniesieniem wkładu w treść przewodnika zapoznaj się z [Academic Honesty Policy](https://www.freecodecamp.org/academic-honesty).
 
 ### Formatowanie przykładowego kodu
 
-Campers will likely use Guide articles as a quick reference to look up syntax. Articles should have simple real-world examples that show common-use cases of that syntax.
+Użytkownicy będą prawdopodobnie używać artykułów przewodnika jako łatwo dostępnego źródła poprawnej składni. Artykuły powinny zawierać proste przykłady z rzeczywistej praktyki programistycznej, które pokażą popularne sposoby stosowania składki w praktyce.
 
-Here are specific formatting guidelines for any code:
+Poniżej przedstawiono wskazówki dotyczące formatowania dla dowolnego kodu:
 
-- JavaScript statements end with a semicolon
-- Use double quotes where applicable
-- Show generally-accepted best practices, particularly for accessibility
-- Comments made should have a space between the comment characters and the comment themselves
+- Deklaracje w JavaScript kończą się średnikiem
+- W stosownych przypadkach należy używać cudzysłowów
+- Pokaż ogólnie przyjęte sprawdzone metody, szczególnie w związku z dostępnością
+- Komentarze powinny zawierać spację między znakami komentarza a samym komentarzem
 
     `// Fix this line`
-- GitHub-flavored markdown supports [syntax highlighting in code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting) for many programming languages. To use it, indicate the language after starting ```
+- GitHub markdown wspiera [kolorowanie składni w blokach kodu](https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting) dla wielu języków programowania. Aby go użyć, wskaż odpowiedni język po rozpoczęciu ```
 ```
     ```html
         <div class='awesome' id='more-awesome'>
@@ -195,40 +195,40 @@ Here are specific formatting guidelines for any code:
 
 ### Dodawanie obrazów do artykułów
 
-For including images, if the images aren't already hosted somewhere else on the web, you'll need to put them online yourself. A good way to do this is to commit them to a GitHub repository of your own, then push them to GitHub. Then you can right-click the image and copy its image source.
+Aby dodać obrazy, jeśli nie są one przechowywane gdzieś indziej w sieci, musisz je samodzielnie umieścić online. Dobrym sposobem aby to zrobić, jest wgranie ich do własnego repozytorium GitHub (commit i push). Następnie można wskazać obraz za pomocą prawego przycisku myszy i skopiować skopiować jego źródło.
 
-Then you'd just need to reference them in your markdown file with this syntax:
+Następnie należy jedynie odwoływać się do nich w pliku markdown za pomocą składni:
 
-`![your alt text](your url)`
+`![twój alt tekst](twój url)`
 
-Then the images should show up when you click the "preview table" tab.
+Następnie obrazy powinny pojawić się po kliknięciu zakładki "preview table".
 
 ### Właściwe rzeczowniki
 
-Proper nouns should use correct capitalization when possible. Below is a list of words as they should appear in Guide articles.
+Właściwe rzeczowniki powinny w miarę możliwości używać poprawnej kapitalizacji. Poniżej znajduje się lista poprawnie sformatowanych słów, które powinny pojawić się w artykułach przewodnika.
 
-- JavaScript (capital letters in "J" and "S" and no abbreviations)
+- JavaScript (wielka litera "J" i "S" obraz brak skrótów)
 - Node.js
 - jQuery
 - SQL
 
-Front-end development (adjective form with a dash) is when you working on the front end (noun form with no dash). The same goes with the back end, full stack, and many other compound terms.
+Front-end development (przymiotnik z myślnikiem) jest wtedy gdy pracujesz nad front end (rzeczownik bez myślnika). Takie same zasady dotyczą sformułowań: back end, full stack, i wielu innych zwrotów złożonych.
 
 ### Gdzie otrzymać pomoc
 
-Technical writing, or the literature of science and technology, is hard. You'll need to take a technical (usually abstract) topic and explain it in a clear, accurate, and objective manner. You'll likely go through several rounds of proofreading and editing before you're happy with the result.
+Pisanie techniczne lub literatura dotycząca nauki i technologii jest trudna. Musisz podjąć techniczny (zazwyczaj abstrakcyjny) temat i wyjaśnić go w jasny, dokładny i obiektywny sposób. Prawdopodobnie przejdziesz kilka rund sprawdzania i edytowania, zanim będziesz zadowolony z rezultatu.
 
-Use the [Hemingway App](http://www.hemingwayapp.com/). There’s nothing magical about this simple tool, but it will automatically detect widely agreed-upon style issues:
+Użyj [Hemingway App](http://www.hemingwayapp.com/). Nie ma nic magicznego w tym prostym narzędziu, ale automatycznie wykryje ono powszechne problemy związane ze stylem pisania:
 
-- passive voice
-- unnecessary adverbs
-- words that have more common equivalents
+- tryb pasywny
+- niepotrzebne przysłówki
+- słowa, które mają więcej synonimów
 
-The Hemingway App will assign a “grade level” for your writing. You should aim for a grade level of 6. Another tool available is the [De-Jargonizer](http://scienceandpublic.com/), originally designed for scientific communication but might help avoid overspecialized wording.
+Aplikacja Hemingway przyzna ocenę twojemu tekstowi. Powinieneś dążyć do oceny "6". Innym dostępnym narzędziem jest [De-Jargonizer](http://scienceandpublic.com/), pierwotnie zaprojektowane do komunikacji naukowej. Może ono pomóc uniknąć stosowania nadmiernie specjalistycznej terminologii.
 
-Also, there's a community of support from a whole team of contributors, whom you can bounce ideas off of and ask for input on your writing. Stay active in the [contributor's chat room](https://gitter.im/freecodecamp/contributors) and ask lots of questions.
+Ponadto istnieje społeczność wsparcia ze strony całego zespołu współpracowników, którym można podrzucić pomysły i poprosić o informacje zwrotne na temat twoich tekstów. Bądź aktywnym w [contributor's chat room](https://gitter.im/freecodecamp/contributors) i zadawaj wiele pytań.
 
-Z twoją pomocą, możemy stworzyć kompleksowe narzędzie referencyjne, które pomoże milionom ludzi uczącym sie programowania. Zarówno tym, którzy uczą sie teraz, jak i tym którzy bedą to robić w kolejnych latach.
+Z twoją pomocą, możemy stworzyć kompleksowe narzędzie referencyjne, które pomoże milionom ludzi uczącym się programowania. Zarówno tym, którzy uczą się teraz, jak i tym którzy będą to robić w kolejnych latach.
 
 ## Licencja
 
@@ -240,10 +240,10 @@ Zawartość tego repozytorium podlega pod następujące licencje:
 
 ## Informacje od tłumacza
 
-Powyższe tłumaczenie ma za zadanie ułatwić pierwszy kontakt z przewodnikiem freeCodeCamp osobom, które na codzień komunikują się w języku polskim. Aktualnie artykuły przewodnika freeCodeCamp (freeCodeCamp Guide) tworzone są tylko i wyłącznie w języku angielskim i w tym języku należy dokonywać ewentualnych kontrybucji.
+Powyższe tłumaczenie ma za zadanie ułatwić pierwszy kontakt z przewodnikiem freeCodeCamp osobom, które na co dzień komunikują się w języku polskim. **Aktualnie artykuły przewodnika freeCodeCamp (freeCodeCamp Guide) tworzone są tylko i wyłącznie w języku angielskim i w tym języku należy dokonywać ewentualnych kontrybucji**.
 
 W powyższym pliku README:
-- Pojawiły się terminy związane z obszarem computer science. Zostały one przetłumaczone tylko w tym miejscu gdzie nei budziały wątpliwości
-- Pojawiły się terminy związane z interfejsem i termonologią GitHub. W większości przypadków nie zostały one przetłumaczone, z wyjątkiem terminu "branch", który w języku polskim powszechnie wystepuje jako "gałąź"
+- Pojawiły się terminy związane z obszarem computer science. Zostały one przetłumaczone tylko w tym miejscu gdzie nie budziły wątpliwości
+- Pojawiły się terminy związane z interfejsem i terminologią GitHub. W większości przypadków nie zostały one przetłumaczone, z wyjątkiem terminu "branch", który w języku polskim powszechnie występuje jako "gałąź"
 - Pojawił się termin "stub article", który tłumaczony dosłownie oznacza "kikut artykułu" co w języku polskim nie oddaje prawidłowo znaczenia sensu tej struktury. Z tego powodu zamiast wymienionego wyżej zwrotu zastosowany został termin "trzon"
-- W sekcji "General writing tips" zachowana została oryginalna forma pisowni osób i zwrotów w języku angielskim tam, gdzie zworty te wyjasniały w jaki sposób należy pisać artykuły
+- W sekcji "General writing tips" zachowana została oryginalna forma pisowni osób i zwrotów w języku angielskim tam, gdzie zwroty te wyjaśniały w jaki sposób należy pisać artykuły

--- a/translations/README.pl.md
+++ b/translations/README.pl.md
@@ -1,0 +1,238 @@
+![](https://s3.amazonaws.com/freecodecamp/wide-social-banner.png)
+
+# Przewodnik freeCodeCamp (freeCodeCamp Guide)
+Społeczność freeCodeCamp tworzy złożony przewodnik z możliwością przeszukiwania zasobów - "freeCodeCamp Guide". To narzędzie referencyjne będzie zawierało tysiące artykułów które obejmują wszystkie dziedziny developementu, designu i data science. Wszystko napisane w formie łatwej do zrozumienia dla osób, które dopiero zaczynają programować.
+
+To repozytorium jest miejscem, gdzie planujemy i rozwijamy artykuły z freeCodeCamp Guide, które nNastępnie hostujemy na naszej własnej stronie w stylu wiki [freeCodeCamp Guide](https://guide.freecodecamp.org).
+
+**Spis treści**
+
+- [Czym są artykuły przewodnika freeCodeCamp?](#what-are-guide-articles)
+- [O czym mogę napisać artykuł?](#what-can-i-write-an-article-about)
+- [Jak wnieść wkład?](#how-to-contribute)
+- [Uruchomienie  przewodnika lokalnie na swoim komputerze](#running-the-guide-locally-on-your-own-computer)
+- [Przewodnik po stylu artykułów](#article-style-guide)
+- [Licencja](#license)
+
+## Czym są artykuły przewodnika freeCodeCamp?
+Artykuły przewodnika mogą dotyczyć składni, wzorców projektowania, tego czym są aria labels lub informacją na temat znaczenia numerów w prawym górnym rogu ekranu na stronie freecodecamp.org. Tutaj znajdziesz [Przykład artykułu o tagach HTML](./src/pages/html/elements/index.md).
+
+## O czym mogę napisać artykuł?
+Twoja pomoc w tworzeniu artykułów jest mile widziana. Nie musisz być ekspertem w danej dziedzinie aby o nim napisać - ten przewodnik (Guide) jest tworzony na zasadach open source, więc nawet jeśli zrobisz błąd, inna osoba prdzej czy później poprawi błąd.
+
+Aby pomóc, znajdź `stub article` (`trzon artykułu`) na [Stronie przewodnika](https://guide.freecodecamp.org/), napisz artykuł, nastpnie stwórz pull request (PR) aby zastąpić trzon twoimi zmianami.
+
+Jeśli nie możesz znaleźć trzonu na temat który cię interesuje, możesz wykonać PR który go stworzy wraz ze szkicem artykułu. Zapraszamy do zadawania pytań jeśli nie jesteś pewien/pewna, gdzie w strukturze katalogów należy umieścić nowy wpis.
+
+Zanim zaczniesz pisać, upewnij się, że przeczytałeś [Przewodnik po stylu artykułów](#article-style-guide) poniżej.
+
+## Jak wnieść wkład?
+Możesz stworzyć PR (Pull Request) ze szkicem artykułu (lub edytować istniejący artykuł) na dwa sposoby:
+
+1) Najłatwiejsza metoda to użycie interfejsu GitHuba. Obejrzyj wideo demonstracyjne lub postępuj według instrukcji poniżej:
+
+![Gif pokazujący kolejne kroki interfejsu GitHuba](https://i.imgur.com/0cmxJwN.gif)
+
+- Otwórz folder "pages" (zlokalizowany w `guides/src`)  i znajdź trzon artykułu który chciałbyś napisać lub edytować. Wszystkie trzony znajdują się w pliku index.md.
+- Kliknij w ikonę ołówka "Edit this file" i dokonaj zmian z uzwgldnieniem składni GitHuba
+- Przewiń na dół ekranu i dodaj commit objaśniający wprowadzone zmiany. Następnie zaznacz przycisk radio "Create a new branch for this commit and start a pull request" i kliknij "Propose file changes"
+- Na następnym ekranie, dodaj dodatkowe szczegóły na temat swojego PR i kliknij przycisk "Create pull request"
+
+
+2) Jeśli preferujesz tworzyć zmiany lokalnie na swoim komputerze przed wysłaniem PR, postepuj zgodnie z instrukcją:
+- Wykonaj Fork tego repozytorium
+- Skopiuj repozytorium na dysk lokalny uruchamiając komendę `git clone https://github.com/TWOJA-NAZWA-UZYTKOWNIKA-GITHUB/guides.git`
+- Dodaj remote upstream uruchamiając komendę `git remote add upstream https://github.com/freeCodeCamp/guides.git`, aby git wiedział gdzie znajduje się oficjalne repozytorium freeCodeCamp guides.
+- Stwórz nową gałąź dla swoich zmian za pomocą komendy `git checkout -b NAZWA-NOWEJ-GALEZI`. Spróbuj nazwać swoją gałąź w taki sposób, aby opisywała temat artykułu np. `fix/ArticleHTMLElements`
+- Stwórz artykuł, dodaj commit ze zmianami komendą `git commit -m "TRESC WIADOMOSCI"`, i wyślij (push) swoją gałąź na GitHub za pomocą komendy `git push origin NAZWA-NOWEJ-GALEZI`
+- Udaj się na stronę swojego forka repozytorium na GitHub i stwórz pull request.
+
+Upewnij się, że lokalny fork pozostaje aktualny w stosunku do oficjalnego repozytorium freeCodeCamp guides. Następnym razem kiedy zechcesz wprowadzić zmiany, sprawdź czy lokalna gałąź `master` jest aktualna komendą `git pull --rebase upstream master`, nim zaczniesz tworzyć nowe rozgałęzienia. Powyższa komenda spowoduje pobranie wszystkich zmian wprowadzonych w oficjalnym repozytorium gałęzi `master` bez tworzenia dodatkowego commita w twoim lokalnym repozytorium.
+
+## Running the Guide locally on your own computer
+
+Finally, if you want to run a version of the guides repository locally, follow these steps:
+
+1. Ensure you have the `yarn` package manager installed `npm install -g yarn`
+2. Fork this repository
+3. :point_down:
+```sh
+git clone https://github.com/YOUR-GITHUB-USERNAME/guides.git
+cd guides
+yarn install
+yarn run dev
+```
+
+In this project, we are using `yarn` because `netlify` builds our site with `yarn`.
+
+## Article style guide
+
+We've written the following guide to writing Guide articles to help you get started contributing.
+
+**Table of Contents**
+
+- [Article title](#article-title)
+- [Modularity](#modularity)
+- [General writing tips](#general-writing-tips)
+- [Formatting example code](#formatting-example-code)
+- [Adding images to articles](#adding-images-to-articles)
+- [Proper nouns](#proper-nouns)
+- [Where to get help](#where-to-get-help)
+
+
+### Tytuł artykułu
+
+Article titles should be as short, concise, and to-the-point as possible. We want campers to quickly find the information they're looking for, and the title should reflect the main theme of the article.
+
+Here are some title examples:
+
+- "HTML Lists"
+- "CSS Borders"
+- "JavaScript For Loop"
+
+The folder name is used in the URL, so only use dashes `-`, numbers `0-9`, and lowercase letters `a-z` for it.
+
+Here are some folder name examples:
+
+- html-lists
+- css-borders
+- javascript-for-loop
+
+However, you can include special characters in the article title.
+
+### Modułowość
+
+Each article should explain exactly one concept, and that concept should be apparent from the article's title.
+
+We can reference other articles by linking to them inline, or in an "Other Resources" section at the end of the article.
+
+Our goal is to have thousands of articles that cover a broad range of technical topics.
+
+### General writing tips
+
+Before you begin writing, create an outline of the topic and think about any coding examples you'll use (if applicable). This helps to organize your thoughts and make the writing process easier.
+
+Articles should be written with short, clear sentences, and use as little jargon as necessary. All jargon should be defined immediately in plain English.
+
+The introduction paragraph should only be 1-2 sentences long and be a simple explanation of the main topic. It should limit the use of any links to other Guide articles, as they can be distracting.
+
+Keep paragraphs short (around 1-4 sentences). People are more likely to read several short paragraphs over a wall of text.
+
+Use active voice instead of passive voice. Generally, it's a stronger and more straightforward way to communicate a subject. For example:
+  - (Passive) The `for` loop in JavaScript is used by programmers to...
+  - (Active) Programmers use the `for` loop in JavaScript to...
+
+If you want to abbreviate a term in your article, write it out fully first, then put the abbreviation in parentheses. For example, "In computer science, an abstract syntax tree (AST) is ..."
+
+Text should use the second person ("you") to help to give it a conversational tone. This way, the text and instructions seem to speak directly to the camper reading it. Try to avoid using the first person ("I", "we", "let's", and "us").
+
+If there are other Guide resources you think campers would benefit from, add them at the bottom in an "Other Resources" section.
+
+You can add diagrams, graphics, or visualizations as necessary. You can also embed relevant YouTube videos and interactive [REPL.it](https://repl.it/) code editors.
+
+Don't use emojis or emoticons in the Guide. freeCodeCamp has a global community, and the cultural meaning of an emoji or emoticon may be different around the world. Also, emojis can render differently on different systems.
+
+Use double quotes where applicable.
+
+Format language keywords as code - this is done with the backtick key (located to the left of the "1" key on a US keyboard) in GitHub-flavored markdown. For example, put backticks around HTML tag names or CSS property names.
+
+Use the Oxford Comma when possible (it is a comma used after the penultimate item in a list of three or more items, before ‘and’ or ‘or’ e.g. an Italian painter, sculptor, and architect). It makes things easier, clearer, and prettier to read.
+
+### Atrybucja
+
+To minimize the potential for plagiarism and maintain integrity in these guides, it is important to give credit where necessary. Any material quoted, or used directly and unchanged, from source material should be wrapped in quotation marks and be adequately cited. Material that is not a direct quote but is still paraphrased from a different resource should also be cited. You can create superscript numerals to mark content that is cited using `<sup></sup>` tags. Like so: <sup>1</sup>
+
+Then, at the bottom of your article, place a `### Sources` heading and include all of your citations numbered to correspond with your marks above:
+
+<blockquote>
+Here is some content that should be cited.<sup>1</sup> And here is even more that should be cited from another source.<sup>2</sup>
+
+### Źródła
+1. [Doe, John. "Authoring Words." *WikiCoder*. January 1, 1970. Accessed: October 20, 2017](#)
+2. [Purdue OWL Staff. "MLA Works Cited: Electronic Sources." *Purdue Online Writing Lab.* October 12, 2017. Accessed: Ocotber 20, 2017.](https://owl.english.purdue.edu/owl/resource/747/08/)
+</blockquote>
+You can check out the Purdue link above to see how to properly cite web sources (they even show how to cite tweets!). Typically, an attribution has a structure like the following:
+
+>Author Last Name, Author First Name. "Article Title." *Publication.* Publisher. Date Published. Date Accessed.
+
+If you cannot find an author or published date, which is common, simply omit these.
+
+Use of proper citations will not only keep the guides reputable, but these citations and links will also provide valuable resources should the reader want to learn more about the topic. Also note that instances of blatant plagiarism will be either removed or have their pull requests declined, and the user will receive a warning. Please refer to and review the [Academic Honesty Policy](https://www.freecodecamp.org/academic-honesty) before contributing.
+
+### Formatowanie przykładowego kodu
+
+Campers will likely use Guide articles as a quick reference to look up syntax. Articles should have simple real-world examples that show common-use cases of that syntax.
+
+Here are specific formatting guidelines for any code:
+
+- JavaScript statements end with a semicolon
+- Use double quotes where applicable
+- Show generally-accepted best practices, particularly for accessibility
+- Comments made should have a space between the comment characters and the comment themselves
+
+    `// Fix this line`
+- GitHub-flavored markdown supports [syntax highlighting in code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting) for many programming languages. To use it, indicate the language after starting ```
+```
+    ```html
+        <div class='awesome' id='more-awesome'>
+          <p>This is text in html</p>
+        </div>
+    ```
+
+    ```javascript
+        function logTheThings(stuff) {
+         console.log(stuff);
+        }
+    ```
+
+    ```css
+       .awesome {
+          background-color: #FCCFCC;
+        }
+    ```
+```
+
+### Dodawanie obrazów do artykułów
+
+For including images, if the images aren't already hosted somewhere else on the web, you'll need to put them online yourself. A good way to do this is to commit them to a GitHub repository of your own, then push them to GitHub. Then you can right-click the image and copy its image source.
+
+Then you'd just need to reference them in your markdown file with this syntax:
+
+`![your alt text](your url)`
+
+Then the images should show up when you click the "preview table" tab.
+
+### Właściwe rzeczowniki
+
+Proper nouns should use correct capitalization when possible. Below is a list of words as they should appear in Guide articles.
+
+- JavaScript (capital letters in "J" and "S" and no abbreviations)
+- Node.js
+- jQuery
+- SQL
+
+Front-end development (adjective form with a dash) is when you working on the front end (noun form with no dash). The same goes with the back end, full stack, and many other compound terms.
+
+### Where to get help
+
+Technical writing, or the literature of science and technology, is hard. You'll need to take a technical (usually abstract) topic and explain it in a clear, accurate, and objective manner. You'll likely go through several rounds of proofreading and editing before you're happy with the result.
+
+Use the [Hemingway App](http://www.hemingwayapp.com/). There’s nothing magical about this simple tool, but it will automatically detect widely agreed-upon style issues:
+
+- passive voice
+- unnecessary adverbs
+- words that have more common equivalents
+
+The Hemingway App will assign a “grade level” for your writing. You should aim for a grade level of 6. Another tool available is the [De-Jargonizer](http://scienceandpublic.com/), originally designed for scientific communication but might help avoid overspecialized wording.
+
+Also, there's a community of support from a whole team of contributors, whom you can bounce ideas off of and ask for input on your writing. Stay active in the [contributor's chat room](https://gitter.im/freecodecamp/contributors) and ask lots of questions.
+
+With your help, we can create a comprehensive reference tool that will help millions of people who are learning to code for years to come.
+
+## Licencja
+
+Copyright (c) 2017 freeCodeCamp.
+
+The content of this repository is bound by the following licenses:
+- The computer software is licensed under the [BSD-3-Clause](./LICENSE.md).
+- The reference content as in ./src/pages and subdirectories is licensed under the [CC-BY-SA-4.0](./LICENSE-freeCodeCamp-Guide-Articles.md).

--- a/translations/README.pl.md
+++ b/translations/README.pl.md
@@ -1,73 +1,73 @@
 ![](https://s3.amazonaws.com/freecodecamp/wide-social-banner.png)
 
 # Przewodnik freeCodeCamp (freeCodeCamp Guide)
-Społeczność freeCodeCamp tworzy złożony przewodnik z możliwością przeszukiwania zasobów - "freeCodeCamp Guide". To narzędzie referencyjne będzie zawierało tysiące artykułów które obejmują wszystkie dziedziny developementu, designu i data science. Wszystko napisane w formie łatwej do zrozumienia dla osób, które dopiero zaczynają programować.
+Społeczność freeCodeCamp tworzy złożony przewodnik z możliwością przeszukiwania zasobów, o nazwie "freeCodeCamp Guide". To narzędzie referencyjne będzie zawierało tysiące artykułów które obejmą wszystkie dziedziny developementu, projektowania i data science. Całość napisana w formie łatwej do zrozumienia dla osób, które dopiero zaczynają swoją przygodę z programowaniem.
 
-To repozytorium jest miejscem, gdzie planujemy i rozwijamy artykuły z freeCodeCamp Guide, które nNastępnie hostujemy na naszej własnej stronie w stylu wiki [freeCodeCamp Guide](https://guide.freecodecamp.org).
+To repozytorium jest miejscem, gdzie planujemy i rozwijamy artykuły z freeCodeCamp Guide, które następnie hostujemy na naszej własnej stronie w stylu wiki [freeCodeCamp Guide](https://guide.freecodecamp.org).
 
 **Spis treści**
 
-- [Czym są artykuły przewodnika freeCodeCamp?](#czym-są-artykuły-przewodnika-freeCodeCamp)
+- [Czym są artykuły przewodnika freeCodeCamp?](#czym-są-artykuły-przewodnika-freecodecamp)
 - [O czym mogę napisać artykuł?](#o-czym-mogę-napisać-artykuł)
 - [Jak wnieść wkład?](#jak-wnieść-wkład)
 - [Uruchomienie przewodnika lokalnie na swoim komputerze](#uruchomienie-przewodnika-lokalnie-na-swoim-komputerze)
-- [Przewodnik po stylowaniu artykułów](#przewodnik-po-stylowaniu-artykułów)
+- [Przewodnik stylowania artykułów](#przewodnik-stylowania-artykułów)
 - [Licencja](#licencja)
 
 ## Czym są artykuły przewodnika freeCodeCamp?
-Artykuły przewodnika mogą dotyczyć składni, wzorców projektowania, tego czym są aria labels lub informacją na temat znaczenia numerów w prawym górnym rogu ekranu na stronie freecodecamp.org. Tutaj znajdziesz [Przykład artykułu o tagach HTML](./src/pages/html/elements/index.md).
+Artykuły przewodnika mogą dotyczyć składni, wzorców projektowania, tego czym są aria labels, lub informacje na temat znaczenia numerów w prawym górnym rogu ekranu na stronie freecodecamp.org. Tutaj znajdziesz [przykład artykułu o tagach HTML](./src/pages/html/elements/index.md).
 
 ## O czym mogę napisać artykuł?
-Twoja pomoc w tworzeniu artykułów jest mile widziana. Nie musisz być ekspertem w danej dziedzinie aby o nim napisać - ten przewodnik (Guide) jest tworzony na zasadach open source, więc nawet jeśli zrobisz błąd, inna osoba prdzej czy później poprawi błąd.
+Twoja pomoc w tworzeniu artykułów jest mile widziana. Nie musisz być ekspertem w danej dziedzinie aby o niej napisać - ten przewodnik jest tworzony na zasadach open source, więc nawet jeśli zrobisz błąd, inna osoba prędzej czy później go poprawi.
 
-Aby pomóc, znajdź `stub article` (`trzon artykułu`) na [Stronie przewodnika](https://guide.freecodecamp.org/), napisz artykuł, nastpnie stwórz pull request (PR) aby zastąpić trzon twoimi zmianami.
+Aby pomóc, znajdź `stub article` (`trzon artykułu`) na [stronie przewodnika](https://guide.freecodecamp.org/), napisz artykuł, nastpnie stwórz pull request (PR) aby zastąpić trzon twoimi zmianami.
 
-Jeśli nie możesz znaleźć trzonu na temat który cię interesuje, możesz wykonać PR który go stworzy wraz ze szkicem artykułu. Zapraszamy do zadawania pytań jeśli nie jesteś pewien/pewna, gdzie w strukturze katalogów należy umieścić nowy wpis.
+Jeśli nie możesz znaleźć trzonu na temat który cię interesuje, możesz wykonać PR który go stworzy (wraz ze szkicem artykułu). Zapraszamy do zadawania pytań jeśli nie jesteś pewien/a, gdzie w strukturze katalogów należy umieścić nowy wpis.
 
-Zanim zaczniesz pisać, upewnij się, że przeczytałeś [Przewodnik po stylu artykułów](#article-style-guide) poniżej.
+Zanim zaczniesz pisać, upewnij się, że przeczytałeś/aś [Przewodnik stylowania artykułów](#przewodnik-stylowania-artykułów) poniżej.
 
 ## Jak wnieść wkład?
-Możesz stworzyć PR (Pull Request) ze szkicem artykułu (lub edytować istniejący artykuł) na dwa sposoby:
+Możesz stworzyć PR (Pull Request) ze szkicem artykułu, lub edytować istniejący artykuł na dwa sposoby:
 
 1) Najłatwiejsza metoda to użycie interfejsu GitHuba. Obejrzyj wideo demonstracyjne lub postępuj według instrukcji poniżej:
 
 ![Gif pokazujący kolejne kroki interfejsu GitHuba](https://i.imgur.com/0cmxJwN.gif)
 
 - Otwórz folder "pages" (zlokalizowany w `guides/src`)  i znajdź trzon artykułu który chciałbyś napisać lub edytować. Wszystkie trzony znajdują się w pliku index.md.
-- Kliknij w ikonę ołówka "Edit this file" i dokonaj zmian z uzwgldnieniem składni GitHuba
+- Kliknij w ikonę ołówka "Edit this file" i dokonaj zmian z uwzględnieniem składni GitHuba
 - Przewiń na dół ekranu i dodaj commit objaśniający wprowadzone zmiany. Następnie zaznacz przycisk radio "Create a new branch for this commit and start a pull request" i kliknij "Propose file changes"
 - Na następnym ekranie, dodaj dodatkowe szczegóły na temat swojego PR i kliknij przycisk "Create pull request"
 
 
-2) Jeśli preferujesz tworzyć zmiany lokalnie na swoim komputerze przed wysłaniem PR, postepuj zgodnie z instrukcją:
+2) Jeśli preferujesz tworzyć zmiany lokalnie na swoim komputerze przed wysłaniem PR, postępuj zgodnie z instrukcją:
 - Wykonaj Fork tego repozytorium
 - Skopiuj repozytorium na dysk lokalny uruchamiając komendę `git clone https://github.com/TWOJA-NAZWA-UZYTKOWNIKA-GITHUB/guides.git`
 - Dodaj remote upstream uruchamiając komendę `git remote add upstream https://github.com/freeCodeCamp/guides.git`, aby git wiedział gdzie znajduje się oficjalne repozytorium freeCodeCamp guides.
 - Stwórz nową gałąź dla swoich zmian za pomocą komendy `git checkout -b NAZWA-NOWEJ-GALEZI`. Spróbuj nazwać swoją gałąź w taki sposób, aby opisywała temat artykułu np. `fix/ArticleHTMLElements`
 - Stwórz artykuł, dodaj commit ze zmianami komendą `git commit -m "TRESC WIADOMOSCI"`, i wyślij (push) swoją gałąź na GitHub za pomocą komendy `git push origin NAZWA-NOWEJ-GALEZI`
-- Udaj się na stronę swojego forka repozytorium na GitHub i stwórz pull request.
+- Udaj się na stronę swojego forka repozytorium na GitHub i stwórz PR (Pull Request).
 
-Upewnij się, że lokalny fork pozostaje aktualny w stosunku do oficjalnego repozytorium freeCodeCamp guides. Następnym razem kiedy zechcesz wprowadzić zmiany, sprawdź czy lokalna gałąź `master` jest aktualna komendą `git pull --rebase upstream master`, nim zaczniesz tworzyć nowe rozgałęzienia. Powyższa komenda spowoduje pobranie wszystkich zmian wprowadzonych w oficjalnym repozytorium gałęzi `master` bez tworzenia dodatkowego commita w twoim lokalnym repozytorium.
+Upewnij się, że lokalny fork pozostaje aktualny w stosunku do oficjalnego repozytorium freeCodeCamp guides. Następnym razem kiedy zechcesz wprowadzić zmiany, nim zaczniesz tworzyć nowe rozgałęzienia, sprawdź czy lokalna gałąź `master` jest aktualna za pomocą komendy `git pull --rebase upstream master`. Powyższa komenda spowoduje pobranie wszystkich zmian wprowadzonych w oficjalnym repozytorium gałęzi `master` bez tworzenia dodatkowego commita w twoim lokalnym repozytorium.
 
 ## Uruchomienie przewodnika lokalnie na swoim komputerze
 
-Finally, if you want to run a version of the guides repository locally, follow these steps:
+Na koniec, jeśli chcesz uruchomić lokalną wersję repozytorium przewodnika, postępuj zgodnie z instrukcją:
 
-1. Ensure you have the `yarn` package manager installed `npm install -g yarn`
-2. Fork this repository
+1. Upewnij się, że masz zainstalowany menadżer pakietów `yarn` za pomocą komendy `npm install -g yarn`
+2. Wykonaj Fork tego repozytorium
 3. :point_down:
 ```sh
-git clone https://github.com/YOUR-GITHUB-USERNAME/guides.git
+git clone https://github.com/TWOJA-NAZWA-UZYTKOWNIKA-GITHUB/guides.git
 cd guides
 yarn install
 yarn run dev
 ```
 
-In this project, we are using `yarn` because `netlify` builds our site with `yarn`.
+W tym projekcie używamy `yarn` ponieważ `netlify` buduje naszą stronę przy pomocy `yarn`.
 
-## Przewodnik po stylowaniu artykułów
+## Przewodnik stylowania artykułów
 
-We've written the following guide to writing Guide articles to help you get started contributing.
+Napisaliśmy poniższy poradnik pisania artykułów, aby pomóc ci rozpocząć tworzenie treści.
 
 **Spis treści**
 

--- a/translations/README.pl.md
+++ b/translations/README.pl.md
@@ -7,12 +7,12 @@ To repozytorium jest miejscem, gdzie planujemy i rozwijamy artykuły z freeCodeC
 
 **Spis treści**
 
-- [Czym są artykuły przewodnika freeCodeCamp?](#what-are-guide-articles)
-- [O czym mogę napisać artykuł?](#what-can-i-write-an-article-about)
+- [Czym są artykuły przewodnika freeCodeCamp?](#czym-sa-artykuly-przewodnika-freeCodeCamp)
+- [O czym mogę napisać artykuł?](#o-czym-moge-napisac-artykul)
 - [Jak wnieść wkład?](#how-to-contribute)
 - [Uruchomienie  przewodnika lokalnie na swoim komputerze](#running-the-guide-locally-on-your-own-computer)
 - [Przewodnik po stylu artykułów](#article-style-guide)
-- [Licencja](#license)
+- [Licencja](#licencja)
 
 ## Czym są artykuły przewodnika freeCodeCamp?
 Artykuły przewodnika mogą dotyczyć składni, wzorców projektowania, tego czym są aria labels lub informacją na temat znaczenia numerów w prawym górnym rogu ekranu na stronie freecodecamp.org. Tutaj znajdziesz [Przykład artykułu o tagach HTML](./src/pages/html/elements/index.md).
@@ -227,12 +227,12 @@ The Hemingway App will assign a “grade level” for your writing. You should a
 
 Also, there's a community of support from a whole team of contributors, whom you can bounce ideas off of and ask for input on your writing. Stay active in the [contributor's chat room](https://gitter.im/freecodecamp/contributors) and ask lots of questions.
 
-With your help, we can create a comprehensive reference tool that will help millions of people who are learning to code for years to come.
+Z twoją pomocą, możemy stworzyć kompleksowe narzędzie referencyjne, które pomoże milionom ludzi uczącym sie programowania. Zarówno tym, którzy uczą sie teraz, jak i tym którzy bedą to robić w kolejnych latach.
 
 ## Licencja
 
 Copyright (c) 2017 freeCodeCamp.
 
-The content of this repository is bound by the following licenses:
+Zawartość tego repozytorium podlega pod nastepujące licencje:
 - The computer software is licensed under the [BSD-3-Clause](./LICENSE.md).
 - The reference content as in ./src/pages and subdirectories is licensed under the [CC-BY-SA-4.0](./LICENSE-freeCodeCamp-Guide-Articles.md).


### PR DESCRIPTION
Dear fCC Guide team,
I allowed myself to create Polish translation of the README.md file from freeCodeCamp Guide repository. At the end of the translations/README.pl.md file I added "Translator's Information" section, translated to English below:

This translation is intended to facilitate the first contact with the freeCodeCamp guide to persons who communicate in the Polish language on daily basis. Currently, the freeCodeCamp guide articles (freeCodeCamp Guide) are created only in English and should be contributed in this language.

In the README file above:
- There are terms related to the computer science. Thoe terms were translated only in those place where they did not raise doubts
- GitHub interface and terminology have appeared. In most cases GitHub terms have not been translated, except for the term "branch", which in Polish is commonly used as "gałąź"
- The term "stub article", which literally translates to "kikut article", does not accurately reflect the meaning of this structure. For this reason, instead of the aforementioned phrase, the term "stem" (trzon) have been used.
 - In the "General writing tips" section, the original spelling of persons and phrases in English has been retained where these phrases explain how to write articles.