### PR TITLE
Added Ubuntu's apt-get Installation for go

### DIFF
--- a/src/pages/go/installing-go/ubuntu-apt-get/index.md
+++ b/src/pages/go/installing-go/ubuntu-apt-get/index.md
@@ -1,0 +1,27 @@
+---
+title: Installing Go in Ubuntu using apt-get
+---
+### Installing Go in Ubuntu using apt-get
+
+Using Ubuntu's Source Package Manager (apt-get) is the easiest way to install Go. You won't get the latest stable version, but for the purpose of learning this should be enough.
+>As of this writing, Ubuntu Xenial's version of go is 1.6.1, while the latest
+stable version is 1.9.1
+
+```sh
+$ sudo apt-get update
+$ sudo apt-get install golang-go
+```
+
+#### Check installation and version of go
+
+To check if go was successfully installed, use:
+
+```sh
+$ go version
+```
+
+This will print to the console the version of go, while at the same time making sure the installation went smoothly.
+
+Sample output:
+
+> go version go1.6.2 linux/amd64


### PR DESCRIPTION
This will be part of a series of installation instructions.

```
guides/src/pages/go/installing-go/index.md
```
Will contain a link to each module of instructions found in:

```
guides/src/pages/go/installing-go/ubuntu-apt-get/index.md
guides/src/pages/go/installing-go/ubuntu-from-source/index.md
guides/src/pages/go/installing-go/windows-installer/index.md
```

This will allow other contributors with different systems to add instructions for their own system (I only have access to windows and Ubuntu).

I was going to include all instructions in one page, but since we are encouraged to be modular, I decided to propose this format. Please let me know if this is a good idea.