### PR TITLE
Add Go Installation Instructions

### DIFF
--- a/src/pages/go/installing-go/index.md
+++ b/src/pages/go/installing-go/index.md
@@ -1,0 +1,20 @@
+---
+title: Installing Go
+---
+### Installing Go 
+
+#### Installing Go in Ubuntu
+* [Installing Go using apt-get](https://guide.freecodecamp.org/go/installing-go/ubuntu-apt-get). This is the easiest method for installing go in ubuntu.
+* [Installing Go using tarball](https://guide.freecodecamp.org/go/installing-go/ubuntu-tarball). Use this method if you wish to install the latest stable version of go.
+
+#### Installing Go in Mac OS X
+* [Installing Go using Package Installer](https://guide.freecodecamp.org/go/installing-go/mac-package-installer). Easiest method to install latest stable version of go.
+* [Installing Go using tarball](https://guide.freecodecamp.org/go/installing-go/mac-tarball). For those that wish to use the terminal.
+
+#### Installing Go in Windows
+* [Installing Go using the MSI Installer](https://guide.freecodecamp.org/go/installing-go/windows-installer)
+
+#### Installing Go from source
+* To install Go from source reffer to the <a href="https://golang.org/doc/install/source" rel="nofollow" target="_blank">installing from source documentation<a/>
+
+Reference: <a href="https://golang.org/doc/install#install" rel="nofollow" target="_blank">golang install documentation</a>


### PR DESCRIPTION
This module will link to installation instructions in other modules:

```
src/pages/go/installing-go/ubuntu-apt-get/index.md
src/pages/go/installing-go/ubuntu-tarball/index.md
src/pages/go/installing-go/mac-package-installer/index.md
src/pages/go/installing-go/mac-tarball/index.md
src/pages/go/installing-go/windows-installer/index.md
```

Since I'm using GitHub to make changes I'll make a pull request for each file.