### PR TITLE
Remove "React Native" from page title.

### DIFF
--- a/src/pages/react-native/hello-world/index.md
+++ b/src/pages/react-native/hello-world/index.md
@@ -1,7 +1,7 @@
 ---
-title: React Native - Hello World
+title: Hello World
 ---
-## React Native - Hello World
+## Hello World
 
 In a traditional webpage, you could easily render `Hello World!` to the screen by writing some HTML like this:
 


### PR DESCRIPTION
The "React Native" in the page title seems redundant.