### PR TITLE
Search results announcements

### DIFF
--- a/src/pageComponents/search/NoResults.jsx
+++ b/src/pageComponents/search/NoResults.jsx
@@ -24,6 +24,13 @@ function NoResults(props) {
           </Button>
         </Link>
       </div>
+      <div
+        aria-live='polite'
+        className='sr-only'
+        role='status'
+        >
+          No results found
+      </div>
     </div>
   );
 }

--- a/src/pageComponents/search/Results.jsx
+++ b/src/pageComponents/search/Results.jsx
@@ -91,12 +91,21 @@ class Results extends PureComponent {
 
   render() {
     const { results = [] } = this.props;
-    if (!results.length) {
-      return null;
-    }
     return (
-      <div className='searchResults'>
-        { this.renderResultItems() }
+      <div>
+        {results.length &&
+          <div className='searchResults'>
+            { this.renderResultItems() }
+          </div>
+        }
+        <div
+          aria-atomic='true'
+          aria-live='polite'
+          className='sr-only'
+          role='status'
+          >
+            {`${results.length} result${results.length === 1 ? '' : 's'} found`}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## What does this do?
This PR adds `aria-live` regions to the search templates in order to announce the result count for screen reader users.

## Change log
- Adds new, visually hidden `div` with `role="status"` and `aria-live="polite"` to `NoResults.jsx` in order to convey "no results" search status.
- Adds new, visually hidden `div` with `role="status"`, `aria-live="polite"`, and `aria-atomic="true"` to `Results.jsx` in order to convey current number of search results.
- Adjusts logic to ensure live region is always available.

## Screens
Everything should look and behave the exact same for sighted mouse users.

![screen shot 2017-10-26 at 12 51 52 pm](https://user-images.githubusercontent.com/1392632/32066027-7af1dd70-ba4c-11e7-9bac-ae597dc7728d.png)

## Related issues

Related to #897.