### PR TITLE
Repository: add .github directory and pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thanks for contributing to the freeCodeCamp Guide! Before you open your pull request (PR), please make sure to do the following:
+
+- Avoid a duplicate PR: search through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes
+- Your changes pass the Travis CI build: any new folder you create in "src/pages" must have an index.md. All articles must have the following as the first three lines in the file:
+
+---
+title: Title of the article that shows up in the site's menu
+---
+
+- If you edit a stub article, your changes are substantial enough to justify removing the stub text ("This article is a stub..." part). We can't accept PRs that only add links to the "More Information" section - a repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file
+- Your PR has a descriptive name (NOT: Update index.md): for example, if you create a "Variables" article inside the "Python" directory, the pull request title should be "Python: add Variables article". Other examples are "Git: edit Git Commit article" or "PHP: create PHP section and add Data Structures article"
+- Add a short description below describing your changes
+
+-->
+
+**Description**


### PR DESCRIPTION
As discussed in #4639 - this PR creates a `.github` directory and a template for PRs. 

I kept the "checklist" as an HTML comment, am open to tweaking the grammar and making it an actual checklist similar to the `freeCodeCamp` repo template. Also, I struggled to articulate where we draw the line for "low-effort" PRs, so I didn't put a bullet point for that - suggestions / discussion welcome.

@QuincyLarson @raisedadead @Bouncey @systimotic @Ethan-Arrowood @erictleung et al, let me know your thoughts 👍 