### PR TITLE
Remove normalise from preCommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "pre-commit": [
     "pre-commit-message",
-    "lint",
-    "normalise"
+    "lint"
   ]
 }


### PR DESCRIPTION
Removed normalise from the precommit script in package.json.
Closes #7238 
