### PR TITLE
Fixed the link to CONTRIBUTING.md in the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Before creating a PR, please make sure to verify the following by marking the ch
   - Your PR should NOT be called `Update index.md` since it does not help the maintainer understand what has been changed.
   - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
   - Other examples are **Git: edit Git Commit article** or **PHP: create PHP section and add Data Structures article**
-- [] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/.github/CONTRIBUTING.md).
+- [] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
 - [] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.
 
 <!-- TO NOTE


### PR DESCRIPTION
The current pull request template link to CONTRIBUTING.md is invalid and gives a 404 not found error. This pull request fixes that issue.

---

<!-- Thank you for contributing to the `guides` repo, it is much appreciated! 😊 -->

<!--

Before creating a PR, please make sure to verify the following by marking the checkboxes below as complete

- [x] Like this!

-->

## ✅️ By submitting this PR, I have verified the following

- [x] Added descriptive name to PR
  - Your PR should NOT be called `Update index.md` since it does not help the maintainer understand what has been changed.
  - For example, if you create a **Variables** article inside the **Python** directory, the pull request title should be **Python: add Variables article**.
  - Other examples are **Git: edit Git Commit article** or **PHP: create PHP section and add Data Structures article**
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/.github/CONTRIBUTING.md).
- [x] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.

<!-- TO NOTE

1. Avoid a duplicate PR by searching through the open pull requests to check that there is not a PR already open that writes the same article or makes similar changes.

2. If you edit a stub article, your changes are substantial enough to justify removing the stub text ("This article is a stub..." part).

We can't accept PRs that only add links to the "More Information" section - a repository script will automatically delete any changes (and revert it to the stub template) if the stub language is still in that file.

3. Your changes must pass the Travis CI build.

Any new folder you create in "src/pages" must have an index.md.

All articles must have the following as the first three lines in the file:

---
title: Article title goes here
---

-->