### PR TITLE
rename web components path to resolve invalid arg error

### DIFF
--- a/src/pages/web-components/how-do-I-use-web-components/index.md
+++ b/src/pages/web-components/how-do-I-use-web-components/index.md
@@ -3,7 +3,7 @@ title: How do I use Web Components?
 ---
 #### How do I use Web Components?
 
-This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/web-components/how-do-I-use-web-components?/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
+This is a stub. <a href='https://github.com/freecodecamp/guides/tree/master/src/pages/web-components/how-do-I-use-web-components/index.md' target='_blank' rel='nofollow'>Help our community expand it</a>.
 
 <ahref='https://github.com/freecodecamp/guides/blob/master/README.md' target='_blank' rel='nofollow'>This quick style guide will help ensure your pull request gets accepted</a>.
 


### PR DESCRIPTION
This PR removes the question mark from the `src/pages/web-components/how-do-I-use-web-components?` path, which currently prevents some contributors from cloning the repo:

![image](https://user-images.githubusercontent.com/16829276/33135172-a48d5a3c-cf6f-11e7-9148-b6a36ae19122.png)

## ✅️ By submitting this PR, I have verified the following
- [x] Added descriptive name to PR
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.
