### PR TITLE
Fix typos and inconsistent capitalization in MacOS terminal section

### DIFF
--- a/src/pages/terminal-commandline/macos-terminal/index.md
+++ b/src/pages/terminal-commandline/macos-terminal/index.md
@@ -33,10 +33,10 @@ Command | Usage
 pwd | Print Working Directory (Where Am I? )
 ls | List contents of current directory
 mkdir | Create a new directory
-touch | Crerate a new file
-cp| copy a file 
-rm | remove a file 
-rm -rf | remove a directory 
+touch | Create a new file
+cp| Copy a file 
+rm | Remove a file 
+rm -rf | Remove a directory 
 
 ### Usage Examples
 


### PR DESCRIPTION
Small fix, just typos 

---

## ✅️ By submitting this PR, I have verified the following

- [x] Added descriptive name to PR
- [x] Reviewed necessary formatting guidelines in [`CONTRIBUTING.md`](https://github.com/freeCodeCamp/guides/blob/master/CONTRIBUTING.md).
- [x] No plagiarized, duplicate or repetitive  content that has been directly copied from another source.